### PR TITLE
Fix wrong phases provided in the WindowRenderEvent

### DIFF
--- a/render/gui/src/main/java/net/flintmc/render/gui/event/WindowRenderEvent.java
+++ b/render/gui/src/main/java/net/flintmc/render/gui/event/WindowRenderEvent.java
@@ -25,7 +25,7 @@ import net.flintmc.render.gui.windowing.Window;
 import net.flintmc.render.gui.windowing.WindowRenderer;
 
 /** Gets fired when a window renderer is being called (PRE and POST). */
-@Subscribable(Phase.PRE)
+@Subscribable({Phase.PRE, Phase.POST})
 public class WindowRenderEvent extends DefaultGuiEvent implements GuiEvent {
 
   private final WindowRenderer windowRenderer;


### PR DESCRIPTION
Fixes a crash when a custom renderer is registered in a Window of the WindowManager.