### PR TITLE
Better error handling in the EventBus

### DIFF
--- a/framework/eventbus/src/main/java/net/flintmc/framework/eventbus/EventBus.java
+++ b/framework/eventbus/src/main/java/net/flintmc/framework/eventbus/EventBus.java
@@ -20,6 +20,8 @@
 package net.flintmc.framework.eventbus;
 
 import net.flintmc.framework.eventbus.event.Event;
+import net.flintmc.framework.eventbus.event.EventDetails;
+import net.flintmc.framework.eventbus.event.subscribe.Subscribable;
 import net.flintmc.framework.eventbus.event.subscribe.Subscribe;
 import net.flintmc.framework.eventbus.method.SubscribeMethod;
 import net.flintmc.framework.eventbus.method.SubscribeMethodBuilder;
@@ -39,7 +41,10 @@ public interface EventBus {
    * @param <E>   The type of the fired event.
    * @return The input event
    * @throws IllegalArgumentException If the given phase is not supported by the given Event
-   * @see Event#getSupportedPhases()
+   * @throws IllegalStateException    If the given event doesn't have the {@link Subscribable}
+   *                                  annotation on itself OR on EXACTLY ONE interface or
+   *                                  superclass
+   * @see EventDetails#getSupportedPhases()
    */
   <E extends Event> E fireEvent(E event, Subscribe.Phase phase);
 
@@ -51,7 +56,10 @@ public interface EventBus {
    * @param <E>           The type of the fired event.
    * @return The input event
    * @throws IllegalArgumentException If the given phase is not supported by the given Event
-   * @see Event#getSupportedPhases()
+   * @throws IllegalStateException    If the given event doesn't have the {@link Subscribable}
+   *                                  annotation on itself OR on EXACTLY ONE interface or
+   *                                  superclass
+   * @see EventDetails#getSupportedPhases()
    */
   default <E extends Event> E fireEvent(E event, Hook.ExecutionTime executionTime) {
     switch (executionTime) {

--- a/framework/eventbus/src/main/java/net/flintmc/framework/eventbus/event/Event.java
+++ b/framework/eventbus/src/main/java/net/flintmc/framework/eventbus/event/Event.java
@@ -19,12 +19,8 @@
 
 package net.flintmc.framework.eventbus.event;
 
-import java.util.Collection;
-import java.util.List;
 import net.flintmc.framework.eventbus.event.subscribe.Subscribable;
 import net.flintmc.framework.eventbus.event.subscribe.Subscribe;
-import net.flintmc.framework.eventbus.event.subscribe.Subscribe.Phase;
-import net.flintmc.framework.eventbus.method.SubscribeMethod;
 
 /**
  * Represents an event. All other events must implement this Interface and have the {@link
@@ -33,29 +29,4 @@ import net.flintmc.framework.eventbus.method.SubscribeMethod;
  * @see Subscribe
  */
 public interface Event {
-
-  /**
-   * Retrieves a list of all methods that are subscribed to this event. This method shouldn't be
-   * implemented by any implementation of this interface because it will be generated
-   * automatically.
-   *
-   * @return An immutable list of methods that are subscribed to this event
-   */
-  default List<SubscribeMethod> getMethods() {
-    throw new UnsupportedOperationException(
-        "Missing @Subscribable on " + this.getClass().getName());
-  }
-
-  /**
-   * Retrieves a list of all phases that are supported by this event that have been declared in the
-   * {@link Subscribable} annotation of this event. This method shouldn't be implemented by any
-   * implementation of this interface because it will be generated automatically.
-   *
-   * @return An immutable list of phases that are supported by this event
-   */
-  default Collection<Phase> getSupportedPhases() {
-    throw new UnsupportedOperationException(
-        "Missing @Subscribable on " + this.getClass().getName());
-  }
-
 }

--- a/framework/eventbus/src/main/java/net/flintmc/framework/eventbus/event/EventDetails.java
+++ b/framework/eventbus/src/main/java/net/flintmc/framework/eventbus/event/EventDetails.java
@@ -1,0 +1,56 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.framework.eventbus.event;
+
+import net.flintmc.framework.eventbus.event.subscribe.Subscribable;
+import net.flintmc.framework.eventbus.event.subscribe.Subscribe.Phase;
+import net.flintmc.framework.eventbus.method.SubscribeMethod;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * This class will automatically be added to classes/interfaces annotated with {@link Subscribable},
+ * it should not be implemented manually.
+ *
+ * @see Subscribable
+ * @see Event
+ */
+public interface EventDetails {
+
+  /**
+   * Retrieves a list of all methods that are subscribed to this event. This method shouldn't be
+   * implemented by any implementation of this interface because it will be generated
+   * automatically.
+   *
+   * @return An immutable list of methods that are subscribed to this event
+   */
+  List<SubscribeMethod> getMethods();
+
+  /**
+   * Retrieves a list of all phases that are supported by this event that have been declared in the
+   * {@link Subscribable} annotation of this event. This method shouldn't be implemented by any
+   * implementation of this interface because it will be generated automatically.
+   *
+   * @return An immutable list of phases that are supported by this event
+   */
+  Collection<Phase> getSupportedPhases();
+
+}

--- a/framework/eventbus/src/main/java/net/flintmc/framework/eventbus/event/subscribe/Subscribable.java
+++ b/framework/eventbus/src/main/java/net/flintmc/framework/eventbus/event/subscribe/Subscribable.java
@@ -19,17 +19,22 @@
 
 package net.flintmc.framework.eventbus.event.subscribe;
 
-import net.flintmc.framework.eventbus.event.Event;
-import net.flintmc.framework.eventbus.event.EventDetails;
-import net.flintmc.processing.autoload.DetectableAnnotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import net.flintmc.framework.eventbus.event.Event;
+import net.flintmc.framework.eventbus.event.EventDetails;
+import net.flintmc.processing.autoload.DetectableAnnotation;
 
 /**
  * Marks a class that implements an {@link Event} as such and must be applied on EVERY event that
  * may be fired.
+ * <p>
+ * If your event is an interface, this annotation has to be on the interface. It can also be on the
+ * implementation, but this is optional UNLESS your implementation implements multiple interfaces
+ * with this annotation. If this is the case, your implementation also requires this annotation to
+ * uniquely identify it.
  *
  * @see Event
  */

--- a/framework/eventbus/src/main/java/net/flintmc/framework/eventbus/event/subscribe/Subscribable.java
+++ b/framework/eventbus/src/main/java/net/flintmc/framework/eventbus/event/subscribe/Subscribable.java
@@ -20,8 +20,8 @@
 package net.flintmc.framework.eventbus.event.subscribe;
 
 import net.flintmc.framework.eventbus.event.Event;
+import net.flintmc.framework.eventbus.event.EventDetails;
 import net.flintmc.processing.autoload.DetectableAnnotation;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -42,7 +42,7 @@ public @interface Subscribable {
    * Retrieves the phases in which this event can be fired.
    *
    * @return The array of phases that are supported by this event
-   * @see Event#getSupportedPhases()
+   * @see EventDetails#getSupportedPhases()
    */
   Subscribe.Phase[] value();
 

--- a/framework/eventbus/src/main/java/net/flintmc/framework/eventbus/event/subscribe/Subscribe.java
+++ b/framework/eventbus/src/main/java/net/flintmc/framework/eventbus/event/subscribe/Subscribe.java
@@ -35,7 +35,9 @@ import java.lang.annotation.Target;
  * Marks a method as an event receiver. The method will then be invoked if the given event has been
  * fired. The method needs to declare at least one parameter which has to be an {@link Event}, the
  * other parameters can be anything from the Injector, {@link Phase} or {@link SubscribeMethod} to
- * get more information about the annotated method in the {@link EventBus}.
+ * get more information about the annotated method in the {@link EventBus}. The {@link Event} in the
+ * parameters needs to have the {@link Subscribable} annotation directly (not through any
+ * superclasses or interfaces).
  *
  * <p>Subscribe methods should be only used in classes annotated with {@link Singleton} and in
  * classes NOT annotated with {@link Service}.
@@ -62,7 +64,9 @@ public @interface Subscribe {
    */
   Phase phase() default Phase.PRE;
 
-  /** An enumeration representing all available phases. */
+  /**
+   * An enumeration representing all available phases.
+   */
   enum Phase {
 
     /**
@@ -70,9 +74,13 @@ public @interface Subscribe {
      * phases.
      */
     ANY,
-    /** Defines the fired event as pre/before. */
+    /**
+     * Defines the fired event as pre/before.
+     */
     PRE,
-    /** Defines the fired event as post/after. */
+    /**
+     * Defines the fired event as post/after.
+     */
     POST
   }
 }


### PR DESCRIPTION
The EventBus has no error handling at all, for example if an event is subscribed with a wrong Subscribable annotation it just wouldn't get called. This PR introduces error messages if the Subscribable annotation is placed wrong and a better description on where it should be placed when creating events.