### PR TITLE
Add function to render the mouse without any screen and fix VersionedGuiInterceptor

### DIFF
--- a/launcher/src/main/java/net/flintmc/launcher/classloading/RootClassLoader.java
+++ b/launcher/src/main/java/net/flintmc/launcher/classloading/RootClassLoader.java
@@ -156,7 +156,7 @@ public class RootClassLoader extends URLClassLoader implements CommonClassLoader
     if (currentlyLoading.contains(name)) {
       throw new CircularClassLoadException(
           "Circular load detected: " + name + " (caused by: " + String
-              .join(", ", currentlyLoading));
+              .join(", ", currentlyLoading) + ")");
     }
 
     // Filter out internal classes

--- a/render/gui/src/main/java/net/flintmc/render/gui/event/ScreenRenderEvent.java
+++ b/render/gui/src/main/java/net/flintmc/render/gui/event/ScreenRenderEvent.java
@@ -17,20 +17,17 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package net.flintmc.mcapi.render.event;
+package net.flintmc.render.gui.event;
 
 import net.flintmc.framework.eventbus.event.Event;
 import net.flintmc.framework.eventbus.event.subscribe.Subscribable;
 import net.flintmc.framework.eventbus.event.subscribe.Subscribe;
 import net.flintmc.framework.eventbus.event.subscribe.Subscribe.Phase;
-import net.flintmc.mcapi.render.image.ImageFullRenderBuilder;
-import net.flintmc.mcapi.render.text.raw.FontRenderBuilder;
 
 /**
  * This event will be fired whenever the screen is rendered. It will be fired in both {@link
  * Subscribe.Phase#PRE} and {@link Subscribe.Phase#POST} phases and it will always be fired on the
- * render thread by Minecraft, which means that in this event for example the {@link
- * FontRenderBuilder} and {@link ImageFullRenderBuilder} can be used to draw objects.
+ * render thread by Minecraft.
  *
  * @see Subscribe
  */

--- a/render/gui/src/main/java/net/flintmc/render/gui/screen/BuiltinScreenDisplayer.java
+++ b/render/gui/src/main/java/net/flintmc/render/gui/screen/BuiltinScreenDisplayer.java
@@ -19,8 +19,13 @@
 
 package net.flintmc.render.gui.screen;
 
-/** Interface abstracting the displaying of Minecraft GUI screens */
+import net.flintmc.render.gui.event.KeyEvent;
+
+/**
+ * Interface abstracting the displaying of Minecraft GUI screens
+ */
 public interface BuiltinScreenDisplayer {
+
   /**
    * Tests whether this screen displayer is capable of displaying the given screen
    *
@@ -33,10 +38,11 @@ public interface BuiltinScreenDisplayer {
    * Changes the currently active GUI screen to the given one. This method may only be called with a
    * screen supported. To test for support, use the {@link #supports(ScreenName)} method.
    *
-   * @param screenName The name of the screen to display
-   * @param args Parameters to pass to the screen
+   * @param screenName The name of the screen to display or {@code null} to display no screen
+   * @param args       Parameters to pass to the screen
    * @throws UnsupportedOperationException If the screen given is not supported by this displayer
-   * @throws IllegalArgumentException If the arguments given are not acceptable for the given screen
+   * @throws IllegalArgumentException      If the arguments given are not acceptable for the given
+   *                                       screen
    */
   void display(ScreenName screenName, Object... args);
 
@@ -46,7 +52,17 @@ public interface BuiltinScreenDisplayer {
    * this displayer}.
    *
    * @return The currently open screen or {@code null} if there is currently no screen opened (e.g.
-   *     the ingame screen without the chat opened)
+   * the ingame screen without the chat opened)
    */
   ScreenName getOpenScreen();
+
+  /**
+   * Displays a dummy screen in Minecraft so that Minecraft will render the mouse like it would be
+   * done when for example opening the chat or an inventory. If there is already another screen like
+   * this opened, nothing will happen. To reset this again display another screen or {@code null}
+   * with {@link #display(ScreenName, Object...)}. Pressing Escape with the {@link KeyEvent} not
+   * being cancelled will also close this dummy and therefore disable that the mouse is being
+   * displayed.
+   */
+  void displayMouse();
 }

--- a/render/gui/src/v1_15_2/java/net/flintmc/render/gui/v1_15_2/VersionedGuiInterceptor.java
+++ b/render/gui/src/v1_15_2/java/net/flintmc/render/gui/v1_15_2/VersionedGuiInterceptor.java
@@ -23,13 +23,19 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import javassist.CannotCompileException;
 import javassist.CtClass;
+import javassist.CtField;
 import javassist.CtMethod;
-import net.flintmc.framework.inject.primitive.InjectionHolder;
+import net.flintmc.framework.eventbus.event.subscribe.PostSubscribe;
+import net.flintmc.framework.inject.InjectedFieldBuilder;
 import net.flintmc.framework.stereotype.type.Type;
 import net.flintmc.render.gui.event.ScreenChangedEvent;
+import net.flintmc.render.gui.event.ScreenRenderEvent;
 import net.flintmc.render.gui.internal.windowing.DefaultWindowManager;
 import net.flintmc.render.gui.screen.ScreenNameMapper;
 import net.flintmc.transform.hook.Hook;
+import net.flintmc.transform.hook.HookFilter;
+import net.flintmc.transform.hook.HookFilters;
+import net.flintmc.transform.hook.HookResult;
 import net.flintmc.transform.javassist.ClassTransform;
 import net.flintmc.transform.javassist.ClassTransformContext;
 import net.flintmc.transform.javassist.CtClassFilter;
@@ -38,50 +44,32 @@ import net.flintmc.util.mappings.ClassMappingProvider;
 import net.flintmc.util.mappings.MethodMapping;
 import net.minecraft.client.Minecraft;
 
-/** 1.15.2 Implementation of the gui interceptor */
+/**
+ * 1.15.2 Implementation of the gui interceptor
+ */
 @Singleton
 public class VersionedGuiInterceptor {
+
   private final ClassMappingProvider mappingProvider;
   private final DefaultWindowManager windowManager;
   private final ScreenNameMapper nameMapper;
+  private final InjectedFieldBuilder.Factory fieldBuilder;
 
   @Inject
   private VersionedGuiInterceptor(
       ClassMappingProvider mappingProvider,
       DefaultWindowManager windowManager,
-      ScreenNameMapper nameMapper) {
+      ScreenNameMapper nameMapper,
+      InjectedFieldBuilder.Factory fieldBuilder) {
     this.mappingProvider = mappingProvider;
     this.windowManager = windowManager;
     this.nameMapper = nameMapper;
+    this.fieldBuilder = fieldBuilder;
   }
 
-  public static boolean preScreenRenderCallback() {
-    DefaultWindowManager windowManager =
-        InjectionHolder.getInjectedInstance(VersionedGuiInterceptor.class).windowManager;
-
-    boolean intrusive = windowManager.isMinecraftWindowRenderedIntrusively();
-    if (intrusive) {
-      windowManager.renderMinecraftWindow();
-    }
-
-    return intrusive;
-  }
-
-  public static void postScreenRenderCallback() {
-    DefaultWindowManager windowManager =
-        InjectionHolder.getInjectedInstance(VersionedGuiInterceptor.class).windowManager;
-    windowManager.renderMinecraftWindow();
-  }
-
-  @Hook(
-      executionTime = {Hook.ExecutionTime.AFTER, Hook.ExecutionTime.BEFORE},
-      className = "net.minecraft.client.gui.IngameGui",
-      methodName = "renderGameOverlay",
-      parameters = @Type(reference = float.class))
-  public void hookIngameRender(Hook.ExecutionTime executionTime) {
-    if (executionTime == Hook.ExecutionTime.AFTER) {
-      postScreenRenderCallback();
-    }
+  @PostSubscribe
+  public void hookMinecraftWindowRender(ScreenRenderEvent event) {
+    this.windowManager.renderMinecraftWindow();
   }
 
   @ClassTransform
@@ -90,34 +78,26 @@ public class VersionedGuiInterceptor {
       value = CtClassFilters.SUBCLASS_OF)
   private void hookScreenRender(ClassTransformContext context) throws CannotCompileException {
     MethodMapping renderMapping =
-        mappingProvider
+        this.mappingProvider
             .get("net.minecraft.client.gui.IRenderable")
             .getMethod("render", int.class, int.class, float.class);
 
     CtClass screenClass = context.getCtClass();
+
+    CtField field = this.fieldBuilder.create()
+        .target(screenClass)
+        .inject(DefaultWindowManager.class)
+        .generate();
+
     for (CtMethod method : screenClass.getDeclaredMethods()) {
       if (!method.getName().equals(renderMapping.getName())) {
         continue;
       }
 
-      /*
-       * Adjustment of the render method:
-       *
-       * if(preRenderCallback() {
-       *   return;
-       * }
-       * [... original method ...]
-       * postRenderCallback();
-       */
-
       method.insertBefore(
-          "if(net.flintmc.render.gui.v1_15_2.VersionedGuiInterceptor.preScreenRenderCallback()) {"
+          "if(" + field.getName() + ".isMinecraftWindowRenderedIntrusively()) {"
               + "   return;"
               + "}");
-
-      method.insertAfter(
-          "net.flintmc.render.gui.v1_15_2.VersionedGuiInterceptor.postScreenRenderCallback();");
-
       break;
     }
   }

--- a/render/gui/src/v1_15_2/java/net/flintmc/render/gui/v1_15_2/event/VersionedScreenRenderEventInjector.java
+++ b/render/gui/src/v1_15_2/java/net/flintmc/render/gui/v1_15_2/event/VersionedScreenRenderEventInjector.java
@@ -17,13 +17,13 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package net.flintmc.mcapi.v1_15_2.render.event;
+package net.flintmc.render.gui.v1_15_2.event;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import net.flintmc.framework.eventbus.EventBus;
 import net.flintmc.framework.stereotype.type.Type;
-import net.flintmc.mcapi.render.event.ScreenRenderEvent;
+import net.flintmc.render.gui.event.ScreenRenderEvent;
 import net.flintmc.transform.hook.Hook;
 
 @Singleton

--- a/render/gui/src/v1_15_2/java/net/flintmc/render/gui/v1_15_2/screen/VersionedBuiltinScreenDisplayer.java
+++ b/render/gui/src/v1_15_2/java/net/flintmc/render/gui/v1_15_2/screen/VersionedBuiltinScreenDisplayer.java
@@ -17,10 +17,13 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package net.flintmc.render.gui.v1_15_2;
+package net.flintmc.render.gui.v1_15_2.screen;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
 import net.flintmc.framework.inject.implement.Implement;
 import net.flintmc.render.gui.screen.BuiltinScreenDisplayer;
 import net.flintmc.render.gui.screen.ScreenName;
@@ -28,48 +31,74 @@ import net.flintmc.render.gui.v1_15_2.lazy.VersionedBuiltinScreenDisplayInit;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screen.Screen;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Consumer;
-
-/** 1.15.2 Implementation of the {@link BuiltinScreenDisplayer} */
+/**
+ * 1.15.2 Implementation of the {@link BuiltinScreenDisplayer}
+ */
 @Singleton
 @Implement(BuiltinScreenDisplayer.class)
 public class VersionedBuiltinScreenDisplayer implements BuiltinScreenDisplayer {
+
   private final Map<ScreenName, Consumer<Object[]>> supportedScreens;
+  private final Screen dummyScreen;
 
   private boolean initialized;
 
   @Inject
   private VersionedBuiltinScreenDisplayer() {
     this.supportedScreens = new HashMap<>();
+    this.dummyScreen = new VersionedDummyScreen();
   }
 
-  /** {@inheritDoc} */
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public boolean supports(ScreenName screenName) {
-    if (!initialized) {
-      VersionedBuiltinScreenDisplayInit.init(supportedScreens);
-      initialized = true;
+    if (!this.initialized) {
+      this.supportedScreens.put(ScreenName.unknown(this.dummyScreen.getClass().getName()),
+          objects -> this.displayMouse());
+      VersionedBuiltinScreenDisplayInit.init(this.supportedScreens);
+
+      this.initialized = true;
     }
 
-    return supportedScreens.containsKey(screenName);
+    return this.supportedScreens.containsKey(screenName);
   }
 
-  /** {@inheritDoc} */
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public void display(ScreenName screenName, Object... args) {
-    if (!supports(screenName)) {
+    if (screenName == null) {
+      Minecraft.getInstance().displayGuiScreen(null);
+      return;
+    }
+
+    if (!this.supports(screenName)) {
       throw new UnsupportedOperationException(
           "This displayer does not support the screen" + screenName);
     }
 
-    supportedScreens.get(screenName).accept(args);
+    this.supportedScreens.get(screenName).accept(args);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public ScreenName getOpenScreen() {
     Screen screen = Minecraft.getInstance().currentScreen;
     return screen != null ? ScreenName.unknown(screen.getClass().getName()) : null;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void displayMouse() {
+    if (Minecraft.getInstance().currentScreen == null) {
+      Minecraft.getInstance().displayGuiScreen(this.dummyScreen);
+    }
   }
 }

--- a/render/gui/src/v1_15_2/java/net/flintmc/render/gui/v1_15_2/screen/VersionedDummyScreen.java
+++ b/render/gui/src/v1_15_2/java/net/flintmc/render/gui/v1_15_2/screen/VersionedDummyScreen.java
@@ -1,0 +1,47 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.render.gui.v1_15_2.screen;
+
+import net.flintmc.render.gui.screen.BuiltinScreenDisplayer;
+import net.flintmc.render.gui.screen.ScreenName;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.util.text.StringTextComponent;
+
+/**
+ * Dummy screen for 1.15.2 that renders nothing and only exists to display the mouse.
+ *
+ * @see BuiltinScreenDisplayer#display(ScreenName, Object...)
+ */
+public class VersionedDummyScreen extends Screen {
+
+  protected VersionedDummyScreen() {
+    super(new StringTextComponent(""));
+  }
+
+  @Override
+  public void render(int p_render_1_, int p_render_2_, float p_render_3_) {
+    // nothing to be rendered
+  }
+
+  @Override
+  protected void init() {
+    // nothing to be initialized
+  }
+}

--- a/render/gui/src/v1_15_2/java/net/flintmc/render/gui/v1_15_2/screen/VersionedDummyScreen.java
+++ b/render/gui/src/v1_15_2/java/net/flintmc/render/gui/v1_15_2/screen/VersionedDummyScreen.java
@@ -20,14 +20,13 @@
 package net.flintmc.render.gui.v1_15_2.screen;
 
 import net.flintmc.render.gui.screen.BuiltinScreenDisplayer;
-import net.flintmc.render.gui.screen.ScreenName;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.util.text.StringTextComponent;
 
 /**
  * Dummy screen for 1.15.2 that renders nothing and only exists to display the mouse.
  *
- * @see BuiltinScreenDisplayer#display(ScreenName, Object...)
+ * @see BuiltinScreenDisplayer#displayMouse()
  */
 public class VersionedDummyScreen extends Screen {
 

--- a/render/gui/src/v1_15_2/java/net/flintmc/render/gui/v1_15_2/screen/VersionedScreenNameMapper.java
+++ b/render/gui/src/v1_15_2/java/net/flintmc/render/gui/v1_15_2/screen/VersionedScreenNameMapper.java
@@ -17,7 +17,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package net.flintmc.render.gui.v1_15_2;
+package net.flintmc.render.gui.v1_15_2.screen;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Singleton;

--- a/transform/minecraft/src/internal/java/net/flintmc/transform/minecraft/internal/PreMinecraftTransformerService.java
+++ b/transform/minecraft/src/internal/java/net/flintmc/transform/minecraft/internal/PreMinecraftTransformerService.java
@@ -21,19 +21,11 @@ package net.flintmc.transform.minecraft.internal;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import javassist.CtClass;
-import javassist.NotFoundException;
-import net.flintmc.framework.inject.primitive.InjectionHolder;
-import net.flintmc.framework.stereotype.service.CtResolver;
 import net.flintmc.framework.stereotype.service.Service;
 import net.flintmc.framework.stereotype.service.Service.State;
 import net.flintmc.framework.stereotype.service.ServiceHandler;
 import net.flintmc.framework.stereotype.service.ServiceNotFoundException;
-import net.flintmc.launcher.LaunchController;
 import net.flintmc.processing.autoload.AnnotationMeta;
-import net.flintmc.processing.autoload.identifier.ClassIdentifier;
-import net.flintmc.transform.launchplugin.FlintLauncherPlugin;
-import net.flintmc.transform.launchplugin.LateInjectedTransformer;
 import net.flintmc.transform.minecraft.MinecraftTransformer;
 
 @Singleton


### PR DESCRIPTION
This PR adds that the user can display the mouse without for example opening the chat or an inventory and fixes that the MinecraftWindow is rendered multiple times in the VersionedGuiInterceptor.