### PR TITLE
Add method to check whether a screen is opened

### DIFF
--- a/render/gui/src/main/java/net/flintmc/render/gui/screen/BuiltinScreenDisplayer.java
+++ b/render/gui/src/main/java/net/flintmc/render/gui/screen/BuiltinScreenDisplayer.java
@@ -47,12 +47,23 @@ public interface BuiltinScreenDisplayer {
   void display(ScreenName screenName, Object... args);
 
   /**
+   * Retrieves whether there is an active GUI screen. An open screen for example is the chat and the
+   * main menu, it is not the ingame screen itself without any other GUI.
+   *
+   * @return {@code true} if there is a screen opened (e.g. the chat, inventory), {@code false}
+   * otherwise
+   * @see #getOpenScreen()
+   */
+  boolean isScreenOpened();
+
+  /**
    * Retrieves the currently active GUI screen, this will never return a screen name of the type
    * {@link ScreenName.Type#FROM_MINECRAFT} and may not be {@link #supports(ScreenName) supported by
-   * this displayer}.
+   * this displayer}. Those screens for example can be the chat, the main menu, etc.
    *
    * @return The currently open screen or {@code null} if there is currently no screen opened (e.g.
    * the ingame screen without the chat opened)
+   * @see #isScreenOpened()
    */
   ScreenName getOpenScreen();
 

--- a/render/gui/src/v1_15_2/java/net/flintmc/render/gui/v1_15_2/screen/VersionedBuiltinScreenDisplayer.java
+++ b/render/gui/src/v1_15_2/java/net/flintmc/render/gui/v1_15_2/screen/VersionedBuiltinScreenDisplayer.java
@@ -87,6 +87,14 @@ public class VersionedBuiltinScreenDisplayer implements BuiltinScreenDisplayer {
    * {@inheritDoc}
    */
   @Override
+  public boolean isScreenOpened() {
+    return Minecraft.getInstance().currentScreen != null;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
   public ScreenName getOpenScreen() {
     Screen screen = Minecraft.getInstance().currentScreen;
     return screen != null ? ScreenName.unknown(screen.getClass().getName()) : null;


### PR DESCRIPTION
This PR adds a method to the BuiltinScreenDisplayer to check whether a screen is opened. This doesn't create an unnecessary instance of ScreenName as `getOpenScreen() != null` would do.