### PR TITLE
Fix that configs aren't being transformed

### DIFF
--- a/framework/config/src/internal/java/net/flintmc/framework/config/internal/generator/base/DefaultConfigImplementer.java
+++ b/framework/config/src/internal/java/net/flintmc/framework/config/internal/generator/base/DefaultConfigImplementer.java
@@ -42,12 +42,14 @@ public class DefaultConfigImplementer implements ConfigImplementer {
     this.pool = pool;
   }
 
-  /** {@inheritDoc} */
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public void implementParsedConfig(CtClass implementation, String name)
       throws NotFoundException, CannotCompileException {
-    for (CtClass anInterface : implementation.getInterfaces()) {
-      if (anInterface.getName().equalsIgnoreCase(ParsedConfig.class.getName())) {
+    for (CtClass ifc : implementation.getInterfaces()) {
+      if (ifc.getName().equals(ParsedConfig.class.getName())) {
         return;
       }
     }

--- a/framework/config/src/internal/java/net/flintmc/framework/config/internal/generator/method/reference/invoker/ReferenceInvocationGenerator.java
+++ b/framework/config/src/internal/java/net/flintmc/framework/config/internal/generator/method/reference/invoker/ReferenceInvocationGenerator.java
@@ -21,6 +21,9 @@ package net.flintmc.framework.config.internal.generator.method.reference.invoker
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 import javassist.CannotCompileException;
 import javassist.ClassPool;
 import javassist.CtClass;
@@ -31,10 +34,6 @@ import net.flintmc.framework.config.generator.GeneratingConfig;
 import net.flintmc.framework.config.internal.generator.base.ConfigClassLoader;
 import net.flintmc.framework.config.internal.generator.base.ImplementationGenerator;
 import net.flintmc.framework.stereotype.PrimitiveTypeLoader;
-
-import java.io.IOException;
-import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
 
 @Singleton
 public class ReferenceInvocationGenerator {
@@ -56,21 +55,24 @@ public class ReferenceInvocationGenerator {
   public ReferenceInvoker generateInvoker(
       GeneratingConfig config, CtMethod[] path, CtMethod getter, CtMethod setter)
       throws CannotCompileException, NotFoundException, IOException, ReflectiveOperationException {
-    CtClass target =
+    CtClass generating =
         this.pool.makeClass(
             "ReferenceInvoker_"
                 + this.idCounter.incrementAndGet()
                 + "_"
                 + this.random.nextInt(Integer.MAX_VALUE));
-    target.addInterface(this.pool.get(ReferenceInvoker.class.getName()));
+    generating.addInterface(this.pool.get(ReferenceInvoker.class.getName()));
 
-    String base = "((" + config.getBaseClass().getName() + ") instance)";
-    String lastAccessor = this.buildPathCasts(path) + base + this.buildPathGetters(path);
+    CtClass targetClass = config.getGeneratedImplementation(
+        config.getBaseClass().getName(), config.getBaseClass());
 
-    target.addMethod(this.generateGetter(lastAccessor, target, getter));
-    target.addMethod(this.generateSetter(lastAccessor, target, setter));
+    String base = "((" + targetClass.getName() + ") $1)";
+    String lastAccessor = this.buildPathCasts(config, path) + base + this.buildPathGetters(path);
 
-    return this.newInstance(target);
+    generating.addMethod(this.generateGetter(lastAccessor, generating, getter));
+    generating.addMethod(this.generateSetter(lastAccessor, generating, setter));
+
+    return this.newInstance(generating);
   }
 
   private ReferenceInvoker newInstance(CtClass target)
@@ -80,13 +82,15 @@ public class ReferenceInvocationGenerator {
     return (ReferenceInvoker) generated.getDeclaredConstructor().newInstance();
   }
 
-  private String buildPathCasts(CtMethod[] path) throws NotFoundException {
+  private String buildPathCasts(GeneratingConfig config, CtMethod[] path) throws NotFoundException {
     StringBuilder builder = new StringBuilder();
 
     for (int i = path.length - 1; i >= 0; i--) {
       CtMethod method = path[i];
 
-      builder.append("((").append(method.getReturnType().getName()).append(')');
+      CtClass returnType = method.getReturnType();
+      CtClass castType = config.getGeneratedImplementation(returnType.getName(), returnType);
+      builder.append("((").append(castType.getName()).append(')');
     }
 
     return builder.toString();

--- a/framework/config/src/internal/java/net/flintmc/framework/config/internal/generator/service/ConfigImplementationMapper.java
+++ b/framework/config/src/internal/java/net/flintmc/framework/config/internal/generator/service/ConfigImplementationMapper.java
@@ -1,0 +1,65 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.framework.config.internal.generator.service;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import java.util.HashMap;
+import java.util.Map;
+import javassist.CtClass;
+import net.flintmc.framework.config.annotation.implemented.ConfigImplementation;
+import net.flintmc.framework.stereotype.service.Service;
+import net.flintmc.framework.stereotype.service.Service.State;
+import net.flintmc.framework.stereotype.service.ServiceHandler;
+import net.flintmc.processing.autoload.AnnotationMeta;
+
+@Singleton
+@Service(value = ConfigImplementation.class, state = State.PRE_INIT)
+public class ConfigImplementationMapper implements ServiceHandler<ConfigImplementation> {
+
+  private final Map<String, CtClass> implementationMappings;
+  private final Map<String, String> launchArguments;
+
+  @Inject
+  private ConfigImplementationMapper(@Named("launchArguments") Map launchArguments) {
+    this.implementationMappings = new HashMap<>();
+    this.launchArguments = launchArguments;
+  }
+
+  public Map<String, CtClass> getImplementationMappings() {
+    return this.implementationMappings;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void discover(AnnotationMeta<ConfigImplementation> annotationMeta) {
+    String version = annotationMeta.getAnnotation().version();
+
+    if (!version.isEmpty() && !launchArguments.get("--game-version").equals(version)) {
+      return;
+    }
+
+    String ifc = annotationMeta.getAnnotation().value().getName();
+    this.implementationMappings.put(ifc, annotationMeta.getClassIdentifier().getLocation());
+  }
+}

--- a/framework/config/src/internal/java/net/flintmc/framework/config/internal/transform/DefaultConfigTransformer.java
+++ b/framework/config/src/internal/java/net/flintmc/framework/config/internal/transform/DefaultConfigTransformer.java
@@ -27,6 +27,7 @@ import javassist.ClassPool;
 import javassist.CtClass;
 import javassist.CtField;
 import javassist.NotFoundException;
+import javassist.bytecode.ClassFile;
 import net.flintmc.framework.config.annotation.implemented.ConfigImplementation;
 import net.flintmc.framework.config.annotation.implemented.ImplementedConfig;
 import net.flintmc.framework.config.generator.ConfigImplementer;
@@ -39,8 +40,13 @@ import net.flintmc.framework.stereotype.service.Service;
 import net.flintmc.framework.stereotype.service.ServiceHandler;
 import net.flintmc.framework.stereotype.service.ServiceNotFoundException;
 import net.flintmc.processing.autoload.AnnotationMeta;
-import net.flintmc.transform.javassist.ClassTransform;
-import net.flintmc.transform.javassist.ClassTransformContext;
+import net.flintmc.transform.exceptions.ClassTransformException;
+import net.flintmc.transform.javassist.ClassTransformMeta;
+import net.flintmc.transform.launchplugin.LateInjectedTransformer;
+import net.flintmc.transform.minecraft.MinecraftTransformer;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -50,9 +56,10 @@ import java.util.Map;
 @Service(
     value = ConfigImplementation.class,
     priority = 2 /* needs to be called after the ConfigGenerationService */)
+@MinecraftTransformer
 @Implement(ConfigTransformer.class)
 public class DefaultConfigTransformer
-    implements ConfigTransformer, ServiceHandler<ConfigImplementation> {
+    implements ConfigTransformer, LateInjectedTransformer, ServiceHandler<ConfigImplementation> {
 
   private final ClassPool pool;
   private final ConfigImplementer configImplementer;
@@ -74,25 +81,19 @@ public class DefaultConfigTransformer
     this.mappings = new HashSet<>();
   }
 
+  @Override
   public Collection<TransformedConfigMeta> getMappings() {
     return this.mappings;
   }
 
+  @Override
   public Collection<PendingTransform> getPendingTransforms() {
     return this.pendingTransforms;
   }
 
-  @ClassTransform
-  public void transformConfigImplementation(ClassTransformContext context)
-      throws CannotCompileException, NotFoundException {
-    // implement methods in classes of the config (including the class annotated with @Config) that
-    // are also half-generated
-    CtClass implementation = context.getCtClass();
-
-    this.implementMethods(implementation);
-  }
-
-  /** {@inheritDoc} */
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public void discover(AnnotationMeta<ConfigImplementation> meta) throws ServiceNotFoundException {
     // implement the configs that are annotated with ImplementedConfig
@@ -113,29 +114,60 @@ public class DefaultConfigTransformer
       return;
     }
 
-    try {
-      TransformedConfigMeta configMeta = new TransformedConfigMeta(annotation.value());
-      this.mappings.add(configMeta);
+    TransformedConfigMeta configMeta = new TransformedConfigMeta(
+        annotation.value(), implementation);
+    this.mappings.add(configMeta);
 
-      // load the class so that the transformer will be called
-      Class<?> definedImplementation =
-          super.getClass().getClassLoader().loadClass(implementation.getName());
-      configMeta.setImplementationClass(definedImplementation);
-
-      if (configMeta.getConfig() == null) {
-        return;
+    for (PendingTransform transform : this.pendingTransforms) {
+      if (transform.getMethod().getDeclaringClass().getName()
+          .equals(annotation.value().getName())) {
+        transform.setConfigMeta(configMeta);
       }
+    }
+  }
 
-      // get the new implementation with the changes from the class transformer
-      CtClass newImplementation = this.pool.get(implementation.getName());
+  @Override
+  public byte[] transform(String className, byte[] classData) throws ClassTransformException {
+    // implement methods in classes of the config (including the class annotated with @Config) that
+    // are also half-generated
 
-      // bind the implementation in the config to be used by the ConfigObjectReference.Parser
-      configMeta
-          .getConfig()
-          .bindGeneratedImplementation(
-              this.pool.get(configMeta.getSuperClass().getName()), newImplementation);
-    } catch (ClassNotFoundException | NotFoundException e) {
-      throw new ServiceNotFoundException("Cannot load transformed config class");
+    boolean shouldTransform = false;
+
+    for (PendingTransform transform : this.pendingTransforms) {
+      if (transform.getConfigMeta() != null &&
+          transform.getConfigMeta().getImplementationCtClass().getName().equals(className)) {
+        shouldTransform = true;
+        break;
+      }
+    }
+
+    if (!shouldTransform) {
+      return classData;
+    }
+
+    CtClass transforming;
+
+    try {
+      transforming =
+          this.pool.makeClass(
+              new ClassFile(new DataInputStream(new ByteArrayInputStream(classData))), true);
+    } catch (IOException exception) {
+      throw new ClassTransformException("unable to read class", exception);
+    }
+
+    try {
+      this.implementMethods(transforming);
+    } catch (CannotCompileException | NotFoundException exception) {
+      throw new ClassTransformException(
+          "Failed to implement config methods: " + className, exception);
+    }
+
+    try {
+      return transforming.toBytecode();
+    } catch (IOException | CannotCompileException exception) {
+      // Basically unreachable.
+      throw new ClassTransformException(
+          "Unable to write class bytecode to byte array: " + className, exception);
     }
   }
 
@@ -149,11 +181,20 @@ public class DefaultConfigTransformer
 
     Collection<PendingTransform> copy = new HashSet<>(this.pendingTransforms);
     for (PendingTransform transform : copy) {
-      ConfigMethod method = transform.getMethod();
-      CtClass declaring = method.getDeclaringClass();
-      if (!implementation.subtypeOf(declaring)) {
+      if (transform.getConfigMeta() == null) {
         continue;
       }
+
+      ConfigMethod method = transform.getMethod();
+      CtClass declaring = method.getDeclaringClass();
+      if (!implementation.getName()
+          .equals(transform.getConfigMeta().getImplementationCtClass().getName())) {
+        continue;
+      }
+
+      // bind the new config class from the new class pool above with
+      // new methods from this transformer
+      method.getConfig().bindGeneratedImplementation(declaring, implementation);
 
       if (!modified
           && implementation.isInterface()
@@ -186,7 +227,7 @@ public class DefaultConfigTransformer
 
         if (method.getDeclaringClass().getName().equals(method.getConfig().getBaseClass().getName())
             && Arrays.stream(implementation.getInterfaces())
-                .noneMatch(iface -> iface.getName().equals(ParsedConfig.class.getName()))) {
+            .noneMatch(iface -> iface.getName().equals(ParsedConfig.class.getName()))) {
           // only the base class annotated with @Config should have the ParsedConfig implementation
           this.configImplementer.implementParsedConfig(
               implementation, method.getConfig().getName());

--- a/framework/config/src/internal/java/net/flintmc/framework/config/internal/transform/PendingTransform.java
+++ b/framework/config/src/internal/java/net/flintmc/framework/config/internal/transform/PendingTransform.java
@@ -24,6 +24,7 @@ import net.flintmc.framework.config.generator.method.ConfigMethod;
 public class PendingTransform {
 
   private final ConfigMethod method;
+  private TransformedConfigMeta configMeta;
 
   public PendingTransform(ConfigMethod method) {
     this.method = method;
@@ -31,5 +32,13 @@ public class PendingTransform {
 
   public ConfigMethod getMethod() {
     return this.method;
+  }
+
+  public TransformedConfigMeta getConfigMeta() {
+    return this.configMeta;
+  }
+
+  public void setConfigMeta(TransformedConfigMeta configMeta) {
+    this.configMeta = configMeta;
   }
 }

--- a/framework/config/src/internal/java/net/flintmc/framework/config/internal/transform/TransformedConfigMeta.java
+++ b/framework/config/src/internal/java/net/flintmc/framework/config/internal/transform/TransformedConfigMeta.java
@@ -19,20 +19,27 @@
 
 package net.flintmc.framework.config.internal.transform;
 
+import javassist.CtClass;
 import net.flintmc.framework.config.generator.GeneratingConfig;
 
 public class TransformedConfigMeta {
 
   private final Class<?> superClass;
+  private final CtClass implementationCtClass;
   private Class<?> implementationClass;
   private GeneratingConfig config;
 
-  public TransformedConfigMeta(Class<?> superClass) {
+  public TransformedConfigMeta(Class<?> superClass, CtClass implementationCtClass) {
     this.superClass = superClass;
+    this.implementationCtClass = implementationCtClass;
   }
 
   public Class<?> getSuperClass() {
     return this.superClass;
+  }
+
+  public CtClass getImplementationCtClass() {
+    return this.implementationCtClass;
   }
 
   public Class<?> getImplementationClass() {

--- a/framework/config/src/main/java/net/flintmc/framework/config/annotation/implemented/ConfigImplementation.java
+++ b/framework/config/src/main/java/net/flintmc/framework/config/annotation/implemented/ConfigImplementation.java
@@ -21,15 +21,14 @@ package net.flintmc.framework.config.annotation.implemented;
 
 import net.flintmc.framework.config.annotation.Config;
 import net.flintmc.processing.autoload.DetectableAnnotation;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * The counterpart to {@link ImplementedConfig}. Use it on the implementations of interfaces annotated with {@link
- * ImplementedConfig} to mark them as their implementation.
+ * The counterpart to {@link ImplementedConfig}. Use it on the implementations of interfaces
+ * annotated with {@link ImplementedConfig} to mark them as their implementation.
  *
  * @see Config
  * @see ImplementedConfig
@@ -40,16 +39,16 @@ import java.lang.annotation.Target;
 public @interface ConfigImplementation {
 
   /**
-   * The interface implemented by this class. This means, the class also needs to {@code implements} the given interface
-   * and have the {@link ImplementedConfig} annotation.
+   * The interface implemented by this class. This means, the class also needs to implement the
+   * given interface and have the {@link ImplementedConfig} annotation.
    *
    * @return The interface implemented by this class
    */
   Class<?> value();
 
   /**
-   * The minecraft version this {@code @Implement} applies to. If the version does not match, the implementation is not
-   * bound.
+   * The minecraft version this {@code @Implement} applies to. If the version does not match, the
+   * implementation is not bound.
    *
    * @return The version this {@code @Implement} applies to
    */


### PR DESCRIPTION
Fixes that configs that are already implemented instead of fully generated aren't being transformed since #105 and CannotCompileErrors if the config interface doesn't contain a setter which is only available in its implementation.