### PR TITLE
Fix that screen rendering isn't being interrupted for intrusive renderers

### DIFF
--- a/render/gui/src/v1_15_2/java/net/flintmc/render/gui/v1_15_2/VersionedGuiInterceptor.java
+++ b/render/gui/src/v1_15_2/java/net/flintmc/render/gui/v1_15_2/VersionedGuiInterceptor.java
@@ -70,7 +70,7 @@ public class VersionedGuiInterceptor {
     this.windowManager.renderMinecraftWindow();
   }
 
-  @ClassTransform("1.15.2")
+  @ClassTransform(version = "1.15.2")
   @CtClassFilter(
       className = "net.minecraft.client.gui.screen.Screen",
       value = CtClassFilters.SUBCLASS_OF)


### PR DESCRIPTION
Fixes a wrong ClassTransform annotation which caused that the class transform hasn't been fired.