### PR TITLE
Fix typo in VersionedWorldGeneratorMapper

### DIFF
--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/world/generator/VersionedWorldGeneratorMapper.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/world/generator/VersionedWorldGeneratorMapper.java
@@ -165,7 +165,7 @@ public class VersionedWorldGeneratorMapper implements WorldGeneratorMapper {
       layers.add(layerJson);
 
       layerJson.addProperty("block", layer.getBlockState().getType().getName().toString());
-      layerJson.addProperty("heght", layer.getLayerHeight());
+      layerJson.addProperty("height", layer.getLayerHeight());
     }
 
     JsonObject structures = new JsonObject();


### PR DESCRIPTION
Fixes a typo that caused the layer height in the flat settings to alwys be 1.