### PR TITLE
Fix some obfuscation errors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ subprojects {
         apply<MavenPublishPlugin>()
         plugins.apply("net.minecrell.licenser")
 
-        version = System.getenv().getOrDefault("VERSION", "2.0.21")
+        version = System.getenv().getOrDefault("VERSION", "1.0.0")
 
         repositories {
             flintRepository()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ subprojects {
         apply<MavenPublishPlugin>()
         plugins.apply("net.minecrell.licenser")
 
-        version = System.getenv().getOrDefault("VERSION", "1.0.0")
+        version = System.getenv().getOrDefault("VERSION", "2.0.21")
 
         repositories {
             flintRepository()

--- a/framework/config/src/internal/java/net/flintmc/framework/config/internal/transform/DefaultConfigTransformer.java
+++ b/framework/config/src/internal/java/net/flintmc/framework/config/internal/transform/DefaultConfigTransformer.java
@@ -22,6 +22,13 @@ package net.flintmc.framework.config.internal.transform;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
 import javassist.CannotCompileException;
 import javassist.ClassPool;
 import javassist.CtClass;
@@ -39,18 +46,11 @@ import net.flintmc.framework.inject.primitive.InjectionHolder;
 import net.flintmc.framework.stereotype.service.Service;
 import net.flintmc.framework.stereotype.service.ServiceHandler;
 import net.flintmc.framework.stereotype.service.ServiceNotFoundException;
+import net.flintmc.launcher.classloading.common.CommonClassLoader;
 import net.flintmc.processing.autoload.AnnotationMeta;
 import net.flintmc.transform.exceptions.ClassTransformException;
-import net.flintmc.transform.javassist.ClassTransformMeta;
 import net.flintmc.transform.launchplugin.LateInjectedTransformer;
 import net.flintmc.transform.minecraft.MinecraftTransformer;
-import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Map;
 
 @Singleton
 @Service(
@@ -127,7 +127,8 @@ public class DefaultConfigTransformer
   }
 
   @Override
-  public byte[] transform(String className, byte[] classData) throws ClassTransformException {
+  public byte[] transform(String className, CommonClassLoader classLoader, byte[] classData)
+      throws ClassTransformException {
     // implement methods in classes of the config (including the class annotated with @Config) that
     // are also half-generated
 

--- a/framework/eventbus/src/internal/java/net/flintmc/framework/eventbus/internal/method/subscribable/SubscribableService.java
+++ b/framework/eventbus/src/internal/java/net/flintmc/framework/eventbus/internal/method/subscribable/SubscribableService.java
@@ -41,6 +41,7 @@ import net.flintmc.framework.stereotype.service.Service;
 import net.flintmc.framework.stereotype.service.Service.State;
 import net.flintmc.framework.stereotype.service.ServiceHandler;
 import net.flintmc.framework.stereotype.service.ServiceNotFoundException;
+import net.flintmc.launcher.classloading.common.CommonClassLoader;
 import net.flintmc.processing.autoload.AnnotationMeta;
 import net.flintmc.transform.exceptions.ClassTransformException;
 import net.flintmc.transform.launchplugin.LateInjectedTransformer;
@@ -81,9 +82,7 @@ public class SubscribableService implements LateInjectedTransformer, ServiceHand
       throws NotFoundException {
     this.methodRegistry = methodRegistry;
 
-    // create our own ClassPool to not clash with the ClassTransformService
-    this.pool = new ClassPool();
-    this.pool.appendSystemPath();
+    this.pool = ClassPool.getDefault();
     this.eventClass = this.pool.get(Event.class.getName());
     this.eventDetailsClass = this.pool.get(EventDetails.class.getName());
 
@@ -111,7 +110,7 @@ public class SubscribableService implements LateInjectedTransformer, ServiceHand
   }
 
   @Override
-  public byte[] transform(String className, byte[] bytes) throws ClassTransformException {
+  public byte[] transform(String className, CommonClassLoader classLoader, byte[] bytes) throws ClassTransformException {
     if (!this.shouldGenerateFields(className) && !this.shouldTransformEventClass(className)) {
       return bytes;
     }

--- a/launcher/src/main/java/net/flintmc/launcher/classloading/RootClassLoader.java
+++ b/launcher/src/main/java/net/flintmc/launcher/classloading/RootClassLoader.java
@@ -229,7 +229,7 @@ public class RootClassLoader extends URLClassLoader implements CommonClassLoader
 
       for (LauncherPlugin plugin : plugins) {
         try {
-          byte[] newBytes = plugin.modifyClass(name, classBytes);
+          byte[] newBytes = plugin.modifyClass(name, loader, classBytes);
           if (newBytes != null) {
             // The plugin has modified the bytes, copy the reference of the array over
             classBytes = newBytes;

--- a/launcher/src/main/java/net/flintmc/launcher/service/LauncherPlugin.java
+++ b/launcher/src/main/java/net/flintmc/launcher/service/LauncherPlugin.java
@@ -21,8 +21,8 @@ package net.flintmc.launcher.service;
 
 import net.flintmc.launcher.LaunchController;
 import net.flintmc.launcher.classloading.RootClassLoader;
+import net.flintmc.launcher.classloading.common.CommonClassLoader;
 import net.flintmc.transform.exceptions.ClassTransformException;
-
 import java.net.URL;
 import java.util.Collections;
 import java.util.List;
@@ -35,6 +35,7 @@ import java.util.Set;
  * <p>Instances are loaded using a {@link java.util.ServiceLoader} or injected by other plugins.
  */
 public interface LauncherPlugin {
+
   /**
    * The name of the plugin, should be a short, but meaningful identifier, such as `Flint`, `Forge`
    * or `Fabric`.
@@ -48,7 +49,8 @@ public interface LauncherPlugin {
    *
    * @param arguments the list of argument objects
    */
-  default void adjustLoadCommandlineArguments(Set<Object> arguments) {}
+  default void adjustLoadCommandlineArguments(Set<Object> arguments) {
+  }
 
   /**
    * Allows the plugin to inject other plugins into the plugin loader.
@@ -65,14 +67,16 @@ public interface LauncherPlugin {
    *
    * @param arguments the current commandline arguments
    */
-  default void modifyCommandlineArguments(List<String> arguments) {}
+  default void modifyCommandlineArguments(List<String> arguments) {
+  }
 
   /**
    * Allows the plugin to modify the behavior of the root classloader.
    *
    * @param classloader the root classloader used for classloading from now on
    */
-  default void configureRootLoader(RootClassLoader classloader) {}
+  default void configureRootLoader(RootClassLoader classloader) {
+  }
 
   /**
    * Gives the plugin a chance to execute code in the launch environment before the launch is
@@ -81,17 +85,20 @@ public interface LauncherPlugin {
    * @param launchClassloader The classloader used in the launch environment
    * @throws PreLaunchException If the pre-launch failed.
    */
-  default void preLaunch(ClassLoader launchClassloader) throws PreLaunchException {}
+  default void preLaunch(ClassLoader launchClassloader) throws PreLaunchException {
+  }
 
   /**
    * Allows the plugin to modify classes before they are loaded.
    *
-   * @param className the name of the class to modify
-   * @param classData the class to modify
+   * @param className   The non-null name of the class to modify
+   * @param classLoader The non-null class loader that will be used to define the modified class
+   * @param classData   The class to modify
    * @return the modified data or null, if no modification was made
    * @throws ClassTransformException If the class fails to transform
    */
-  default byte[] modifyClass(String className, byte[] classData) throws ClassTransformException {
+  default byte[] modifyClass(String className, CommonClassLoader classLoader, byte[] classData)
+      throws ClassTransformException {
     return null;
   }
 
@@ -99,7 +106,7 @@ public interface LauncherPlugin {
    * Allows the plugin to override where resources can be found.
    *
    * @param resourceName the name of the resource to be found
-   * @param suggested the currently suggested url, may be null
+   * @param suggested    the currently suggested url, may be null
    * @return the adjusted url or null to indicate no change
    */
   default URL adjustResourceURL(String resourceName, URL suggested) {

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/items/mapper/VersionedMinecraftItemMapper.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/items/mapper/VersionedMinecraftItemMapper.java
@@ -31,6 +31,7 @@ import net.flintmc.mcapi.items.meta.ItemMeta;
 import net.flintmc.mcapi.items.type.ItemType;
 import net.minecraft.item.Item;
 import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.util.IItemProvider;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.registry.Registry;
 
@@ -89,7 +90,12 @@ public class VersionedMinecraftItemMapper implements MinecraftItemMapper {
                         "Unknown item " + stack.getType().getResourceLocation()));
 
     net.minecraft.item.ItemStack result =
-        new net.minecraft.item.ItemStack(() -> item, stack.getStackSize());
+        new net.minecraft.item.ItemStack(new IItemProvider() {
+          @Override
+          public Item asItem() {
+            return item;
+          }
+        }, stack.getStackSize());
 
     if (stack.hasItemMeta()) {
       result.setTag(new CompoundNBT());

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/resources/VersionedResourceLocation.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/resources/VersionedResourceLocation.java
@@ -19,30 +19,32 @@
 
 package net.flintmc.mcapi.v1_15_2.resources;
 
-import java.io.IOException;
-import java.io.InputStream;
 import net.flintmc.framework.inject.assisted.Assisted;
 import net.flintmc.framework.inject.assisted.AssistedInject;
 import net.flintmc.framework.inject.implement.Implement;
 import net.flintmc.mcapi.resources.ResourceLocation;
 import net.minecraft.client.Minecraft;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 /**
  * 1.15.2 implementation of a minecraft resource location.
  */
 @Implement(value = ResourceLocation.class, version = "1.15.2")
-public class VersionedResourceLocation extends net.minecraft.util.ResourceLocation
-    implements ResourceLocation {
+public class VersionedResourceLocation implements ResourceLocation {
+
+  private final net.minecraft.util.ResourceLocation wrapped;
 
   @AssistedInject
   private VersionedResourceLocation(@Assisted("fullPath") String fullPath) {
-    super(fullPath);
+    this.wrapped = new net.minecraft.util.ResourceLocation(fullPath);
   }
 
   @AssistedInject
   private VersionedResourceLocation(
       @Assisted("nameSpace") String nameSpace, @Assisted("path") String path) {
-    super(nameSpace, path);
+    this.wrapped = new net.minecraft.util.ResourceLocation(nameSpace, path);
   }
 
   /**
@@ -50,14 +52,30 @@ public class VersionedResourceLocation extends net.minecraft.util.ResourceLocati
    */
   @SuppressWarnings("unchecked")
   public <T> T getHandle() {
-    return (T) this;
+    return (T) this.wrapped;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getPath() {
+    return this.wrapped.getPath();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getNamespace() {
+    return this.wrapped.getNamespace();
   }
 
   /**
    * {@inheritDoc}
    */
   public InputStream openInputStream() throws IOException {
-    return Minecraft.getInstance().getResourceManager().getResource(this).getInputStream();
+    return Minecraft.getInstance().getResourceManager().getResource(this.wrapped).getInputStream();
   }
 
   /**
@@ -65,7 +83,7 @@ public class VersionedResourceLocation extends net.minecraft.util.ResourceLocati
    */
   @Override
   public boolean exists() {
-    return Minecraft.getInstance().getResourceManager().hasResource(this);
+    return Minecraft.getInstance().getResourceManager().hasResource(this.wrapped);
   }
 
   /**
@@ -73,6 +91,6 @@ public class VersionedResourceLocation extends net.minecraft.util.ResourceLocati
    */
   @Override
   public String toString() {
-    return this.namespace + ":" + this.path;
+    return this.getNamespace() + ":" + this.getPath();
   }
 }

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/resources/VersionedResourceLocation.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/resources/VersionedResourceLocation.java
@@ -31,18 +31,19 @@ import net.minecraft.client.Minecraft;
  * 1.16.5 implementation of a minecraft resource location.
  */
 @Implement(value = ResourceLocation.class, version = "1.16.5")
-public class VersionedResourceLocation extends net.minecraft.util.ResourceLocation
-    implements ResourceLocation {
+public class VersionedResourceLocation implements ResourceLocation {
+
+  private final net.minecraft.util.ResourceLocation wrapped;
 
   @AssistedInject
   private VersionedResourceLocation(@Assisted("fullPath") String fullPath) {
-    super(fullPath);
+    this.wrapped = new net.minecraft.util.ResourceLocation(fullPath);
   }
 
   @AssistedInject
   private VersionedResourceLocation(
       @Assisted("nameSpace") String nameSpace, @Assisted("path") String path) {
-    super(nameSpace, path);
+    this.wrapped = new net.minecraft.util.ResourceLocation(nameSpace, path);
   }
 
   /**
@@ -50,14 +51,30 @@ public class VersionedResourceLocation extends net.minecraft.util.ResourceLocati
    */
   @SuppressWarnings("unchecked")
   public <T> T getHandle() {
-    return (T) this;
+    return (T) this.wrapped;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getPath() {
+    return this.wrapped.getPath();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getNamespace() {
+    return this.wrapped.getNamespace();
   }
 
   /**
    * {@inheritDoc}
    */
   public InputStream openInputStream() throws IOException {
-    return Minecraft.getInstance().getResourceManager().getResource(this).getInputStream();
+    return Minecraft.getInstance().getResourceManager().getResource(this.wrapped).getInputStream();
   }
 
   /**
@@ -65,16 +82,14 @@ public class VersionedResourceLocation extends net.minecraft.util.ResourceLocati
    */
   @Override
   public boolean exists() {
-    return Minecraft.getInstance().getResourceManager().hasResource(this);
+    return Minecraft.getInstance().getResourceManager().hasResource(this.wrapped);
   }
 
   /**
-   * Retrieves the resource location as a {@link String}.
-   *
-   * @return The resource location as a string.
+   * {@inheritDoc}
    */
   @Override
   public String toString() {
-    return this.namespace + ":" + this.path;
+    return this.getNamespace() + ":" + this.getPath();
   }
 }

--- a/render/gui/src/v1_15_2/java/net/flintmc/render/gui/v1_15_2/screen/VersionedScreenNameMapper.java
+++ b/render/gui/src/v1_15_2/java/net/flintmc/render/gui/v1_15_2/screen/VersionedScreenNameMapper.java
@@ -19,12 +19,15 @@
 
 package net.flintmc.render.gui.v1_15_2.screen;
 
+import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.HashMap;
 import java.util.Map;
 import net.flintmc.framework.inject.implement.Implement;
 import net.flintmc.render.gui.screen.ScreenName;
 import net.flintmc.render.gui.screen.ScreenNameMapper;
+import net.flintmc.util.mappings.ClassMapping;
+import net.flintmc.util.mappings.ClassMappingProvider;
 
 @Singleton
 @Implement(value = ScreenNameMapper.class, version = "1.15.2")
@@ -57,12 +60,26 @@ public class VersionedScreenNameMapper implements ScreenNameMapper {
         ScreenName.minecraft(ScreenName.DUMMY));
   }
 
+  private final ClassMappingProvider classMappingProvider;
+
+  @Inject
+  private VersionedScreenNameMapper(ClassMappingProvider classMappingProvider) {
+    this.classMappingProvider = classMappingProvider;
+  }
+
   /**
    * {@inheritDoc}
    */
   @Override
   public ScreenName fromClass(String className) {
     ScreenName screenName = KNOWN_NAMES.get(className);
+    if (screenName == null) {
+      ClassMapping mapping = this.classMappingProvider.get(className);
+      if (mapping != null) {
+        screenName = KNOWN_NAMES.get(mapping.getDeobfuscatedName());
+      }
+    }
+
     return screenName != null ? screenName : ScreenName.unknown(className);
   }
 }

--- a/render/gui/src/v1_16_5/java/net/flintmc/render/gui/v1_16_5/screen/VersionedScreenNameMapper.java
+++ b/render/gui/src/v1_16_5/java/net/flintmc/render/gui/v1_16_5/screen/VersionedScreenNameMapper.java
@@ -19,12 +19,15 @@
 
 package net.flintmc.render.gui.v1_16_5.screen;
 
+import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.HashMap;
 import java.util.Map;
 import net.flintmc.framework.inject.implement.Implement;
 import net.flintmc.render.gui.screen.ScreenName;
 import net.flintmc.render.gui.screen.ScreenNameMapper;
+import net.flintmc.util.mappings.ClassMapping;
+import net.flintmc.util.mappings.ClassMappingProvider;
 
 @Singleton
 @Implement(value = ScreenNameMapper.class, version = "1.16.5")
@@ -55,12 +58,27 @@ public class VersionedScreenNameMapper implements ScreenNameMapper {
         ScreenName.minecraft(ScreenName.DUMMY));
   }
 
+  private final ClassMappingProvider classMappingProvider;
+
+  @Inject
+  private VersionedScreenNameMapper(ClassMappingProvider classMappingProvider) {
+    this.classMappingProvider = classMappingProvider;
+  }
+
   /**
    * {@inheritDoc}
    */
   @Override
   public ScreenName fromClass(String className) {
     ScreenName screenName = KNOWN_NAMES.get(className);
+
+    if (screenName == null) {
+      ClassMapping mapping = this.classMappingProvider.get(className);
+      if (mapping != null) {
+        screenName = KNOWN_NAMES.get(mapping.getDeobfuscatedName());
+      }
+    }
+
     return screenName != null ? screenName : ScreenName.unknown(className);
   }
 }

--- a/transform/asm/src/internal/java/net/flintmc/transform/asm/internal/MethodVisitService.java
+++ b/transform/asm/src/internal/java/net/flintmc/transform/asm/internal/MethodVisitService.java
@@ -24,6 +24,7 @@ import com.google.inject.Singleton;
 import net.flintmc.framework.inject.method.MethodInjector;
 import net.flintmc.framework.stereotype.service.Service;
 import net.flintmc.framework.stereotype.service.ServiceHandler;
+import net.flintmc.launcher.classloading.common.CommonClassLoader;
 import net.flintmc.processing.autoload.AnnotationMeta;
 import net.flintmc.transform.asm.MethodVisit;
 import net.flintmc.transform.asm.MethodVisitorContext;
@@ -63,7 +64,7 @@ public class MethodVisitService implements ServiceHandler<MethodVisit>, LateInje
   }
 
   @Override
-  public byte[] transform(String s, byte[] bytes) {
+  public byte[] transform(String s, CommonClassLoader classLoader, byte[] bytes) {
     ClassMapping classMapping = this.classMappingProvider.get(s);
     if (classMapping == null) {
       return bytes;

--- a/transform/javassist/src/internal/java/net/flintmc/transform/javassist/internal/DefaultClassTransformService.java
+++ b/transform/javassist/src/internal/java/net/flintmc/transform/javassist/internal/DefaultClassTransformService.java
@@ -35,6 +35,7 @@ import javassist.bytecode.ClassFile;
 import net.flintmc.framework.inject.implement.Implement;
 import net.flintmc.framework.stereotype.service.Service;
 import net.flintmc.framework.stereotype.service.ServiceHandler;
+import net.flintmc.launcher.classloading.common.CommonClassLoader;
 import net.flintmc.processing.autoload.AnnotationMeta;
 import net.flintmc.transform.exceptions.ClassTransformException;
 import net.flintmc.transform.javassist.ClassTransform;
@@ -119,11 +120,12 @@ public class DefaultClassTransformService
   }
 
   @Override
-  public byte[] transform(String className, byte[] bytes) throws ClassTransformException {
+  public byte[] transform(String className, CommonClassLoader classLoader, byte[] bytes)
+      throws ClassTransformException {
     ClassMapping mapping = classMappingProvider.get(className);
     String deobfuscatedName = mapping != null ? mapping.getDeobfuscatedName() : className;
-    if (!deobfuscatedName.startsWith("net.minecraft") && !deobfuscatedName
-        .startsWith("com.mojang")) {
+    if (!deobfuscatedName.startsWith("net.minecraft")
+        && !deobfuscatedName.startsWith("com.mojang")) {
       // Skip classes which are not part of minecraft or some Mojang library
       return null;
     }

--- a/transform/launcher-plugin/src/main/java/net/flintmc/transform/launchplugin/LateInjectedTransformer.java
+++ b/transform/launcher-plugin/src/main/java/net/flintmc/transform/launchplugin/LateInjectedTransformer.java
@@ -19,6 +19,7 @@
 
 package net.flintmc.transform.launchplugin;
 
+import net.flintmc.launcher.classloading.common.CommonClassLoader;
 import net.flintmc.transform.exceptions.ClassTransformException;
 
 public interface LateInjectedTransformer {
@@ -26,12 +27,14 @@ public interface LateInjectedTransformer {
   /**
    * Transform a class.
    *
-   * @param className A class name.
-   * @param classData A byte array reassembling a class.
+   * @param className   The non-null name of the class to modify
+   * @param classLoader The non-null class loader that will be used to define the modified class
+   * @param classData   The class to modify
    * @return A derivative of class data.
    * @throws ClassTransformException If the class transformation failed.
    */
-  default byte[] transform(String className, byte[] classData) throws ClassTransformException {
+  default byte[] transform(String className, CommonClassLoader classLoader, byte[] classData)
+      throws ClassTransformException {
     return classData;
   }
 

--- a/transform/minecraft-obfuscator/src/main/java/net/flintmc/transform/minecraft/obfuscate/MinecraftInstructionObfuscator.java
+++ b/transform/minecraft-obfuscator/src/main/java/net/flintmc/transform/minecraft/obfuscate/MinecraftInstructionObfuscator.java
@@ -23,8 +23,10 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import javassist.ClassPool;
+import net.flintmc.framework.packages.PackageClassLoader;
 import net.flintmc.launcher.classloading.RootClassLoader;
 import net.flintmc.launcher.classloading.common.ClassInformation;
+import net.flintmc.launcher.classloading.common.CommonClassLoader;
 import net.flintmc.launcher.classloading.common.CommonClassLoaderHelper;
 import net.flintmc.transform.asm.ASMUtils;
 import net.flintmc.transform.exceptions.ClassTransformException;
@@ -60,11 +62,12 @@ public class MinecraftInstructionObfuscator implements LateInjectedTransformer {
   }
 
   @Override
-  public byte[] transform(String className, byte[] classData) throws ClassTransformException {
+  public byte[] transform(String className, CommonClassLoader classLoader, byte[] classData) throws ClassTransformException {
     if (!obfuscated) {
       return classData;
     }
-    if (!className.startsWith("net.flintmc")) {
+    if (!className.startsWith("net.flintmc") && !(classLoader instanceof PackageClassLoader)) {
+      // only reobfuscate flint classes and classes from packages
       return classData;
     }
 

--- a/transform/shadow/src/internal/java/net/flintmc/transform/shadow/internal/ShadowHelper.java
+++ b/transform/shadow/src/internal/java/net/flintmc/transform/shadow/internal/ShadowHelper.java
@@ -1,0 +1,71 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.transform.shadow.internal;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import javassist.CtClass;
+import javassist.CtMethod;
+import javassist.NotFoundException;
+import net.flintmc.launcher.LaunchController;
+import net.flintmc.processing.autoload.identifier.MethodIdentifier;
+import net.flintmc.util.mappings.utils.RemappingMethodLocationResolver;
+import java.util.Arrays;
+
+@Singleton
+public class ShadowHelper {
+
+  private final RemappingMethodLocationResolver remappingMethodLocationResolver;
+
+  @Inject
+  private ShadowHelper() {
+    this.remappingMethodLocationResolver = new RemappingMethodLocationResolver();
+  }
+
+  public boolean hasMethod(CtClass ctClass, String name, CtClass[] parameters)
+      throws NotFoundException {
+    return this.getMethod(ctClass, name, parameters) != null;
+  }
+
+  public CtMethod getMethod(CtClass ctClass, String name, CtClass[] parameters)
+      throws NotFoundException {
+    for (CtMethod method : ctClass.getDeclaredMethods()) {
+      if (method.getName().equals(name) && Arrays
+          .equals(method.getParameterTypes(), parameters)) {
+        return method;
+      }
+    }
+
+    return null;
+  }
+
+  public CtMethod getLocation(MethodIdentifier identifier)
+      throws ClassNotFoundException {
+    // we need to load the interface class so parameter and return types get appropriately
+    // remapped before getLocation is called
+    Class.forName(identifier.getOwner(), false,
+        LaunchController.getInstance().getRootLoader());
+    identifier.setMethodResolver(() -> this.remappingMethodLocationResolver
+        .getLocation(identifier.getOwner(), identifier.getName(),
+            identifier.getParameters()));
+    return identifier.getLocation();
+  }
+
+}

--- a/transform/shadow/src/internal/java/net/flintmc/transform/shadow/internal/ShadowService.java
+++ b/transform/shadow/src/internal/java/net/flintmc/transform/shadow/internal/ShadowService.java
@@ -126,44 +126,5 @@ public class ShadowService implements ServiceHandler<Shadow> {
         }
       }
     }
-
-    /*
-    try {
-      this.handleMethodProxies(meta, transforming);
-    } catch (ClassNotFoundException | NotFoundException exception) {
-      this.logger.trace(
-          String.format(
-              "Failed to generate a method proxy (@MethodProxy) in %s for shadow interface %s",
-              transforming.getName(), ifc.getName()),
-          exception);
-    }
-    try {
-      this.handleFieldCreators(meta, transforming);
-    } catch (NotFoundException | CannotCompileException exception) {
-      this.logger.trace(
-          String.format(
-              "Failed to generate a field (@FieldCreate) in %s for shadow interface %s",
-              transforming.getName(), ifc.getName()),
-          exception);
-    }
-    try {
-      this.handleFieldGetters(meta, transforming);
-    } catch (NotFoundException | CannotCompileException | ClassNotFoundException exception) {
-      this.logger.trace(
-          String.format(
-              "Failed to generate a field getter (@FieldGetter) in %s for shadow interface %s",
-              transforming.getName(), ifc.getName()),
-          exception);
-    }
-    try {
-      this.handleFieldSetters(meta, transforming);
-    } catch (CannotCompileException | NotFoundException | ClassNotFoundException exception) {
-      this.logger.trace(
-          String.format(
-              "Failed to generate a field setter (@FieldSetter) in %s for shadow interface %s",
-              transforming.getName(), ifc.getName()),
-          exception);
-    }
-    */
   }
 }

--- a/transform/shadow/src/internal/java/net/flintmc/transform/shadow/internal/ShadowService.java
+++ b/transform/shadow/src/internal/java/net/flintmc/transform/shadow/internal/ShadowService.java
@@ -24,26 +24,23 @@ import com.google.common.collect.Multimap;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
-import javassist.*;
+import java.util.Collection;
+import java.util.Map;
+import javassist.CtClass;
 import net.flintmc.framework.inject.logging.InjectLogger;
 import net.flintmc.framework.stereotype.service.Service;
 import net.flintmc.framework.stereotype.service.ServiceHandler;
 import net.flintmc.framework.stereotype.service.ServiceNotFoundException;
-import net.flintmc.launcher.LaunchController;
 import net.flintmc.processing.autoload.AnnotationMeta;
-import net.flintmc.processing.autoload.identifier.MethodIdentifier;
+import net.flintmc.transform.exceptions.ClassTransformException;
 import net.flintmc.transform.javassist.ClassTransform;
 import net.flintmc.transform.javassist.ClassTransformContext;
-import net.flintmc.transform.shadow.*;
+import net.flintmc.transform.shadow.Shadow;
+import net.flintmc.transform.shadow.internal.handler.RegisteredShadowHandler;
+import net.flintmc.transform.shadow.internal.handler.ShadowHandlerService;
 import net.flintmc.util.mappings.ClassMapping;
 import net.flintmc.util.mappings.ClassMappingProvider;
-import net.flintmc.util.mappings.FieldMapping;
-import net.flintmc.util.mappings.MethodMapping;
-import net.flintmc.util.mappings.utils.RemappingMethodLocationResolver;
 import org.apache.logging.log4j.Logger;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Map;
 
 @Singleton
 @Service(value = Shadow.class, priority = -20000, state = Service.State.AFTER_IMPLEMENT)
@@ -51,21 +48,21 @@ public class ShadowService implements ServiceHandler<Shadow> {
 
   private final Logger logger;
   private final ClassMappingProvider classMappingProvider;
+  private final ShadowHandlerService service;
   private final Multimap<String, AnnotationMeta<Shadow>> transforms;
   private final String version;
-  private final RemappingMethodLocationResolver remappingMethodLocationResolver;
 
   @Inject
   private ShadowService(
       @InjectLogger Logger logger,
       ClassMappingProvider classMappingProvider,
-      @Named("launchArguments") Map launchArguments) {
+      @Named("launchArguments") Map launchArguments,
+      ShadowHandlerService service) {
     this.logger = logger;
     this.classMappingProvider = classMappingProvider;
+    this.service = service;
     this.transforms = HashMultimap.create();
     this.version = (String) launchArguments.get("--game-version");
-    this.remappingMethodLocationResolver
-        = new RemappingMethodLocationResolver();
   }
 
   @Override
@@ -104,231 +101,69 @@ public class ShadowService implements ServiceHandler<Shadow> {
     }
 
     Collection<AnnotationMeta<Shadow>> metas = this.transforms.get(name);
-    ClassPool classPool = transforming.getClassPool();
 
     for (AnnotationMeta<Shadow> meta : metas) {
       CtClass ifc = meta.getClassIdentifier().getLocation();
       transforming.addInterface(ifc);
 
-      try {
-        this.handleMethodProxies(meta, classPool, transforming);
-      } catch (ClassNotFoundException | NotFoundException exception) {
-        this.logger.trace(
-            String.format(
-                "Failed to generate a method proxy (@MethodProxy) in %s for shadow interface %s",
-                transforming.getName(), ifc.getName()),
-            exception);
-      }
-      try {
-        this.handleFieldCreators(meta, transforming);
-      } catch (NotFoundException | CannotCompileException exception) {
-        this.logger.trace(
-            String.format(
-                "Failed to generate a field (@FieldCreate) in %s for shadow interface %s",
-                transforming.getName(), ifc.getName()),
-            exception);
-      }
-      try {
-        this.handleFieldGetters(meta, transforming);
-      } catch (NotFoundException | CannotCompileException | ClassNotFoundException exception) {
-        this.logger.trace(
-            String.format(
-                "Failed to generate a field getter (@FieldGetter) in %s for shadow interface %s",
-                transforming.getName(), ifc.getName()),
-            exception);
-      }
-      try {
-        this.handleFieldSetters(meta, transforming);
-      } catch (CannotCompileException | NotFoundException | ClassNotFoundException exception) {
-        this.logger.trace(
-            String.format(
-                "Failed to generate a field setter (@FieldSetter) in %s for shadow interface %s",
-                transforming.getName(), ifc.getName()),
-            exception);
-      }
+      this.transformMethods(meta, ifc, transforming);
     }
   }
 
-  private void handleFieldCreators(AnnotationMeta<Shadow> identifierMeta,
-      CtClass ctClass)
-      throws NotFoundException, CannotCompileException {
-    for (AnnotationMeta<FieldCreate> fieldCreateMeta :
-        identifierMeta.getMetaData(FieldCreate.class)) {
-      FieldCreate fieldCreate = fieldCreateMeta.getAnnotation();
-      boolean exist = false;
-      for (CtField field : ctClass.getFields()) {
-        if (field.getName().equals(fieldCreate.name())) {
-          exist = true;
-        }
-      }
-      if (!exist) {
-        CtField ctField =
-            new CtField(
-                ctClass.getClassPool().get(fieldCreate.typeName()),
-                fieldCreate.name(), ctClass);
-        if (fieldCreate.defaultValue().isEmpty()) {
-          ctClass.addField(ctField);
-        } else {
-          ctClass.addField(ctField, fieldCreate.defaultValue());
+  private void transformMethods(
+      AnnotationMeta<Shadow> meta, CtClass ifc, CtClass transforming) {
+    for (RegisteredShadowHandler<?> handler : this.service.getHandlers()) {
+      for (AnnotationMeta subMeta : meta.getMetaData(handler.getAnnotationType())) {
+        try {
+          handler.getHandler().transform(ifc, transforming, subMeta);
+        } catch (ClassTransformException e) {
+          this.logger.trace(
+              String.format("Failed to execute @%s from shadow interface %s on class %s",
+                  handler.getAnnotationType().getSimpleName(),
+                  ifc.getName(),
+                  transforming.getName()),
+              e);
         }
       }
     }
-  }
 
-  private void handleFieldSetters(AnnotationMeta<Shadow> identifierMeta,
-      CtClass ctClass)
-      throws CannotCompileException, NotFoundException, ClassNotFoundException {
-    for (AnnotationMeta<FieldSetter> fieldSetterMeta :
-        identifierMeta.getMetaData(FieldSetter.class)) {
-      FieldSetter fieldSetter = fieldSetterMeta.getAnnotation();
-      CtMethod method = getLocation(fieldSetterMeta.getIdentifier());
-
-      CtClass[] parameters = method.getParameterTypes();
-      if (parameters.length != 1) {
-        throw new IllegalArgumentException(
-            "Setter " + method + " must have one arguments.");
-      }
-      if (method.getReturnType() != CtClass.voidType) {
-        throw new IllegalStateException(
-            "Return type for " + method + " must be void");
-      }
-
-      String fieldName = null;
-      ClassMapping classMapping = classMappingProvider.get(ctClass.getName());
-      if (classMapping != null) {
-        fieldName = classMapping.getField(fieldSetter.value()).getName();
-      }
-      if (fieldName == null) {
-        fieldName = fieldSetter.value();
-      }
-
-      CtField field = ctClass.getField(fieldName);
-
-      if (Modifier.isFinal(field.getModifiers())) {
-        field.setModifiers(field.getModifiers() & ~Modifier.FINAL);
-      }
-
-      if (!hasMethod(ctClass, method.getName(), parameters)) {
-        ctClass.addMethod(
-            CtMethod.make(
-                String.format(
-                    "public void %s(%s arg){this.%s = arg;}",
-                    method.getName(), parameters[0].getName(),
-                    fieldName),
-                ctClass));
-      }
+    /*
+    try {
+      this.handleMethodProxies(meta, transforming);
+    } catch (ClassNotFoundException | NotFoundException exception) {
+      this.logger.trace(
+          String.format(
+              "Failed to generate a method proxy (@MethodProxy) in %s for shadow interface %s",
+              transforming.getName(), ifc.getName()),
+          exception);
     }
-  }
-
-  private boolean hasMethod(CtClass ctClass, String name, CtClass[] parameters)
-      throws NotFoundException {
-    for (CtMethod method : ctClass.getDeclaredMethods()) {
-      if (method.getName().equals(name) && Arrays
-          .equals(method.getParameterTypes(), parameters)) {
-        return true;
-      }
+    try {
+      this.handleFieldCreators(meta, transforming);
+    } catch (NotFoundException | CannotCompileException exception) {
+      this.logger.trace(
+          String.format(
+              "Failed to generate a field (@FieldCreate) in %s for shadow interface %s",
+              transforming.getName(), ifc.getName()),
+          exception);
     }
-
-    return false;
-  }
-
-  private void handleFieldGetters(AnnotationMeta<Shadow> identifierMeta,
-      CtClass ctClass)
-      throws NotFoundException, CannotCompileException, ClassNotFoundException {
-    for (AnnotationMeta<FieldGetter> fieldGetterMeta :
-        identifierMeta.getMetaData(FieldGetter.class)) {
-      FieldGetter fieldGetter = fieldGetterMeta.getAnnotation();
-      CtMethod method = this.getLocation(fieldGetterMeta.getIdentifier());
-
-      CtClass[] parameters = method.getParameterTypes();
-      if (parameters.length != 0) {
-        throw new IllegalArgumentException(
-            "Getter " + method + " must not have arguments.");
-      }
-      if (!hasMethod(ctClass, method.getName(), parameters)) {
-        ClassMapping classMapping = classMappingProvider.get(ctClass.getName());
-        String name;
-        if (classMapping != null) {
-          FieldMapping field = classMapping.getField(fieldGetter.value());
-          if (field != null) {
-            name = field.getName();
-          } else {
-            name = fieldGetter.value();
-          }
-        } else {
-          name = fieldGetter.value();
-        }
-
-        ctClass.addMethod(
-            CtMethod.make(
-                String.format(
-                    "public %s %s(){return this.%s;}",
-                    method.getReturnType().getName(), method.getName(), name),
-                ctClass));
-      }
+    try {
+      this.handleFieldGetters(meta, transforming);
+    } catch (NotFoundException | CannotCompileException | ClassNotFoundException exception) {
+      this.logger.trace(
+          String.format(
+              "Failed to generate a field getter (@FieldGetter) in %s for shadow interface %s",
+              transforming.getName(), ifc.getName()),
+          exception);
     }
-  }
-
-  private void handleMethodProxies(
-      AnnotationMeta<Shadow> identifierMeta, ClassPool classPool,
-      CtClass targetClass)
-      throws ClassNotFoundException, NotFoundException {
-    for (AnnotationMeta<MethodProxy> methodProxyMeta :
-        identifierMeta.getMetaData(MethodProxy.class)) {
-      CtMethod proxyMethod = getLocation(methodProxyMeta.getIdentifier());
-
-      CtClass[] parameters = proxyMethod.getParameterTypes();
-      CtClass[] classes = new CtClass[parameters.length];
-      for (int i = 0; i < classes.length; i++) {
-        classes[i] = classPool.get(parameters[i].getName());
-      }
-
-      CtMethod target;
-      ClassMapping classMapping = this.classMappingProvider
-          .get(targetClass.getName());
-      if (classMapping != null) {
-        MethodMapping methodMapping = classMapping
-            .getMethod(proxyMethod.getName(), parameters);
-        if (methodMapping != null) {
-          target = targetClass
-              .getDeclaredMethod(methodMapping.getName(), classes);
-          if (!methodMapping.getName().equals(proxyMethod.getName())) {
-            try {
-              String src =
-                  String.format(
-                      "public %s %s(){return this.%s($$);}",
-                      target.getReturnType().getName(), proxyMethod.getName(),
-                      target.getName());
-
-              targetClass.addMethod(CtMethod.make(src, targetClass));
-            } catch (CannotCompileException e) {
-              this.logger.trace(
-                  String.format(
-                      "Failed to compile the method proxy for %s#%s",
-                      targetClass.getName(), proxyMethod.getName()),
-                  e);
-            }
-          }
-        } else {
-          target = targetClass
-              .getDeclaredMethod(proxyMethod.getName(), classes);
-        }
-      } else {
-        target = targetClass.getDeclaredMethod(proxyMethod.getName(), classes);
-      }
-      target.setModifiers(Modifier.setPublic(target.getModifiers()));
+    try {
+      this.handleFieldSetters(meta, transforming);
+    } catch (CannotCompileException | NotFoundException | ClassNotFoundException exception) {
+      this.logger.trace(
+          String.format(
+              "Failed to generate a field setter (@FieldSetter) in %s for shadow interface %s",
+              transforming.getName(), ifc.getName()),
+          exception);
     }
-  }
-
-  private CtMethod getLocation(MethodIdentifier identifier)
-      throws ClassNotFoundException {
-    // we need to load the interface class so parameter and return types get appropriately
-    // remapped before getLocation is called
-    Class.forName(identifier.getOwner(), false,
-        LaunchController.getInstance().getRootLoader());
-    identifier.setMethodResolver(() -> this.remappingMethodLocationResolver
-        .getLocation(identifier.getOwner(), identifier.getName(),
-            identifier.getParameters()));
-    return identifier.getLocation();
+    */
   }
 }

--- a/transform/shadow/src/internal/java/net/flintmc/transform/shadow/internal/handler/RegisterShadowHandler.java
+++ b/transform/shadow/src/internal/java/net/flintmc/transform/shadow/internal/handler/RegisterShadowHandler.java
@@ -17,29 +17,22 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package net.flintmc.transform.shadow;
+package net.flintmc.transform.shadow.internal.handler;
 
 import net.flintmc.processing.autoload.DetectableAnnotation;
-
+import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * Indicates a method in a shadow that executes a private method that cannot be called from the
- * outside. Method must return the field type and must not have parameters.
- *
- * <p>Example: {@code private void test(){...}} can be accessed with {@code void test();}
- *
- * @see Shadow
- * @see FieldGetter
- * @see FieldSetter
- */
+@Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
-@DetectableAnnotation(requiresParent = true)
-public @interface MethodProxy {
+@DetectableAnnotation
+public @interface RegisterShadowHandler {
 
-  String value() default "";
+  Class<? extends Annotation> value();
+
+  int priority();
+
 }

--- a/transform/shadow/src/internal/java/net/flintmc/transform/shadow/internal/handler/RegisteredShadowHandler.java
+++ b/transform/shadow/src/internal/java/net/flintmc/transform/shadow/internal/handler/RegisteredShadowHandler.java
@@ -17,29 +17,31 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package net.flintmc.transform.shadow;
+package net.flintmc.transform.shadow.internal.handler;
 
-import net.flintmc.processing.autoload.DetectableAnnotation;
+import java.lang.annotation.Annotation;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+public class RegisteredShadowHandler<A extends Annotation> {
 
-/**
- * Indicates a method in a shadow that executes a private method that cannot be called from the
- * outside. Method must return the field type and must not have parameters.
- *
- * <p>Example: {@code private void test(){...}} can be accessed with {@code void test();}
- *
- * @see Shadow
- * @see FieldGetter
- * @see FieldSetter
- */
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
-@DetectableAnnotation(requiresParent = true)
-public @interface MethodProxy {
+  private final Class<A> annotationType;
+  private final int priority;
+  private final ShadowHandler<A> handler;
 
-  String value() default "";
+  public RegisteredShadowHandler(Class<A> annotationType, int priority, ShadowHandler<A> handler) {
+    this.annotationType = annotationType;
+    this.priority = priority;
+    this.handler = handler;
+  }
+
+  public Class<A> getAnnotationType() {
+    return this.annotationType;
+  }
+
+  public int getPriority() {
+    return this.priority;
+  }
+
+  public ShadowHandler<A> getHandler() {
+    return this.handler;
+  }
 }

--- a/transform/shadow/src/internal/java/net/flintmc/transform/shadow/internal/handler/ShadowHandler.java
+++ b/transform/shadow/src/internal/java/net/flintmc/transform/shadow/internal/handler/ShadowHandler.java
@@ -17,29 +17,16 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package net.flintmc.transform.shadow;
+package net.flintmc.transform.shadow.internal.handler;
 
-import net.flintmc.processing.autoload.DetectableAnnotation;
+import java.lang.annotation.Annotation;
+import javassist.CtClass;
+import net.flintmc.processing.autoload.AnnotationMeta;
+import net.flintmc.transform.exceptions.ClassTransformException;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+public interface ShadowHandler<A extends Annotation> {
 
-/**
- * Indicates a method in a shadow that executes a private method that cannot be called from the
- * outside. Method must return the field type and must not have parameters.
- *
- * <p>Example: {@code private void test(){...}} can be accessed with {@code void test();}
- *
- * @see Shadow
- * @see FieldGetter
- * @see FieldSetter
- */
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
-@DetectableAnnotation(requiresParent = true)
-public @interface MethodProxy {
+  void transform(CtClass shadowInterface, CtClass implementation, AnnotationMeta<A> meta)
+      throws ClassTransformException;
 
-  String value() default "";
 }

--- a/transform/shadow/src/internal/java/net/flintmc/transform/shadow/internal/handler/ShadowHandlerService.java
+++ b/transform/shadow/src/internal/java/net/flintmc/transform/shadow/internal/handler/ShadowHandlerService.java
@@ -1,0 +1,61 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.transform.shadow.internal.handler;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import net.flintmc.framework.inject.primitive.InjectionHolder;
+import net.flintmc.framework.stereotype.service.CtResolver;
+import net.flintmc.framework.stereotype.service.Service;
+import net.flintmc.framework.stereotype.service.ServiceHandler;
+import net.flintmc.processing.autoload.AnnotationMeta;
+import net.flintmc.processing.autoload.identifier.ClassIdentifier;
+
+@Singleton
+@Service(value = RegisterShadowHandler.class, priority = -25000, state = Service.State.AFTER_IMPLEMENT)
+public class ShadowHandlerService implements ServiceHandler<RegisterShadowHandler> {
+
+  private final List<RegisteredShadowHandler<?>> handlers;
+
+  @Inject
+  private ShadowHandlerService() {
+    this.handlers = new ArrayList<>();
+  }
+
+  public List<RegisteredShadowHandler<?>> getHandlers() {
+    return this.handlers;
+  }
+
+  @Override
+  public void discover(AnnotationMeta<RegisterShadowHandler> meta) {
+    ClassIdentifier identifier = meta.getClassIdentifier();
+    RegisterShadowHandler annotation = meta.getAnnotation();
+    ShadowHandler<?> handler =
+        InjectionHolder.getInjectedInstance(CtResolver.get(identifier.getLocation()));
+
+    this.handlers
+        .add(new RegisteredShadowHandler(annotation.value(), annotation.priority(), handler));
+
+    this.handlers.sort(Comparator.comparingInt(RegisteredShadowHandler::getPriority));
+  }
+}

--- a/transform/shadow/src/internal/java/net/flintmc/transform/shadow/internal/handler/defaults/ShadowFieldCreateHandler.java
+++ b/transform/shadow/src/internal/java/net/flintmc/transform/shadow/internal/handler/defaults/ShadowFieldCreateHandler.java
@@ -1,0 +1,74 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.transform.shadow.internal.handler.defaults;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.CtField;
+import javassist.NotFoundException;
+import net.flintmc.processing.autoload.AnnotationMeta;
+import net.flintmc.transform.exceptions.ClassTransformException;
+import net.flintmc.transform.shadow.FieldCreate;
+import net.flintmc.transform.shadow.internal.handler.RegisterShadowHandler;
+import net.flintmc.transform.shadow.internal.handler.ShadowHandler;
+import net.flintmc.util.mappings.utils.line.MappingLineParser;
+
+@Singleton
+@RegisterShadowHandler(value = FieldCreate.class, priority = 1)
+public class ShadowFieldCreateHandler implements ShadowHandler<FieldCreate> {
+
+  private final MappingLineParser lineParser;
+
+  @Inject
+  private ShadowFieldCreateHandler(MappingLineParser lineParser) {
+    this.lineParser = lineParser;
+  }
+
+  @Override
+  public void transform(
+      CtClass shadowInterface, CtClass implementation, AnnotationMeta<FieldCreate> meta)
+      throws ClassTransformException {
+    FieldCreate fieldCreate = meta.getAnnotation();
+    for (CtField field : implementation.getFields()) {
+      if (field.getName().equals(fieldCreate.name())) {
+        return;
+      }
+    }
+
+    try {
+      CtField ctField =
+          new CtField(
+              implementation.getClassPool().get(fieldCreate.typeName()),
+              fieldCreate.name(), implementation);
+      if (fieldCreate.defaultValue().isEmpty()) {
+        implementation.addField(ctField);
+      } else {
+        String line = this.lineParser.translateMappings(fieldCreate.defaultValue());
+        implementation.addField(ctField, line);
+      }
+    } catch (NotFoundException exception) {
+      throw new ClassTransformException("Type " + fieldCreate.typeName() + " not found", exception);
+    } catch (CannotCompileException exception) {
+      throw new ClassTransformException("Cannot compile created field", exception);
+    }
+  }
+}

--- a/transform/shadow/src/internal/java/net/flintmc/transform/shadow/internal/handler/defaults/ShadowGetterHandler.java
+++ b/transform/shadow/src/internal/java/net/flintmc/transform/shadow/internal/handler/defaults/ShadowGetterHandler.java
@@ -1,0 +1,89 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.transform.shadow.internal.handler.defaults;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.CtMethod;
+import javassist.NotFoundException;
+import net.flintmc.processing.autoload.AnnotationMeta;
+import net.flintmc.transform.exceptions.ClassTransformException;
+import net.flintmc.transform.shadow.FieldGetter;
+import net.flintmc.transform.shadow.internal.ShadowHelper;
+import net.flintmc.transform.shadow.internal.handler.RegisterShadowHandler;
+import net.flintmc.transform.shadow.internal.handler.ShadowHandler;
+import net.flintmc.util.mappings.ClassMapping;
+import net.flintmc.util.mappings.ClassMappingProvider;
+import net.flintmc.util.mappings.FieldMapping;
+
+@Singleton
+@RegisterShadowHandler(value = FieldGetter.class, priority = 3)
+public class ShadowGetterHandler implements ShadowHandler<FieldGetter> {
+
+  private final ClassMappingProvider mappingProvider;
+  private final ShadowHelper helper;
+
+  @Inject
+  private ShadowGetterHandler(ClassMappingProvider mappingProvider, ShadowHelper helper) {
+    this.mappingProvider = mappingProvider;
+    this.helper = helper;
+  }
+
+  @Override
+  public void transform(
+      CtClass shadowInterface, CtClass implementation, AnnotationMeta<FieldGetter> meta)
+      throws ClassTransformException {
+    try {
+      FieldGetter fieldGetter = meta.getAnnotation();
+      CtMethod method = this.helper.getLocation(meta.getIdentifier());
+
+      CtClass[] parameters = method.getParameterTypes();
+      if (parameters.length != 0) {
+        throw new IllegalArgumentException(
+            "Getter " + method + " must not have arguments.");
+      }
+      if (!this.helper.hasMethod(implementation, method.getName(), parameters)) {
+        ClassMapping classMapping = this.mappingProvider.get(implementation.getName());
+        String name;
+        if (classMapping != null) {
+          FieldMapping field = classMapping.getField(fieldGetter.value());
+          if (field != null) {
+            name = field.getName();
+          } else {
+            name = fieldGetter.value();
+          }
+        } else {
+          name = fieldGetter.value();
+        }
+
+        implementation.addMethod(
+            CtMethod.make(
+                String.format(
+                    "public %s %s(){return this.%s;}",
+                    method.getReturnType().getName(), method.getName(), name),
+                implementation));
+      }
+    } catch (NotFoundException | CannotCompileException | ClassNotFoundException exception) {
+      throw new ClassTransformException(exception);
+    }
+  }
+}

--- a/transform/shadow/src/internal/java/net/flintmc/transform/shadow/internal/handler/defaults/ShadowProxyHandler.java
+++ b/transform/shadow/src/internal/java/net/flintmc/transform/shadow/internal/handler/defaults/ShadowProxyHandler.java
@@ -1,0 +1,103 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.transform.shadow.internal.handler.defaults;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.CtMethod;
+import javassist.Modifier;
+import javassist.NotFoundException;
+import net.flintmc.processing.autoload.AnnotationMeta;
+import net.flintmc.transform.exceptions.ClassTransformException;
+import net.flintmc.transform.shadow.MethodProxy;
+import net.flintmc.transform.shadow.internal.ShadowHelper;
+import net.flintmc.transform.shadow.internal.handler.RegisterShadowHandler;
+import net.flintmc.transform.shadow.internal.handler.ShadowHandler;
+import net.flintmc.util.mappings.ClassMapping;
+import net.flintmc.util.mappings.ClassMappingProvider;
+import net.flintmc.util.mappings.MethodMapping;
+
+@Singleton
+@RegisterShadowHandler(value = MethodProxy.class, priority = 2)
+public class ShadowProxyHandler implements ShadowHandler<MethodProxy> {
+
+  private final ClassMappingProvider mappingProvider;
+  private final ShadowHelper helper;
+
+  @Inject
+  private ShadowProxyHandler(ClassMappingProvider mappingProvider, ShadowHelper helper) {
+    this.mappingProvider = mappingProvider;
+    this.helper = helper;
+  }
+
+  @Override
+  public void transform(
+      CtClass shadowInterface, CtClass implementation, AnnotationMeta<MethodProxy> meta)
+      throws ClassTransformException {
+    try {
+      CtMethod proxyMethod = this.helper.getLocation(meta.getIdentifier());
+
+      CtClass[] parameters = proxyMethod.getParameterTypes();
+      CtClass[] classes = new CtClass[parameters.length];
+      for (int i = 0; i < classes.length; i++) {
+        classes[i] = implementation.getClassPool().get(parameters[i].getName());
+      }
+
+      CtMethod target;
+      ClassMapping classMapping = this.mappingProvider.get(implementation.getName());
+      MethodMapping methodMapping =
+          classMapping != null ? classMapping.getMethod(proxyMethod.getName(), parameters) : null;
+
+      if (methodMapping != null) {
+        target = implementation.getDeclaredMethod(methodMapping.getName(), classes);
+        if (!methodMapping.getName().equals(proxyMethod.getName())) {
+          String src =
+              String.format(
+                  "public %s %s(%s){return this.%s($$);}",
+                  target.getReturnType().getName(), proxyMethod.getName(),
+                  this.buildParameters(classes), target.getName());
+
+          implementation.addMethod(CtMethod.make(src, implementation));
+        }
+      } else {
+        target = implementation.getDeclaredMethod(proxyMethod.getName(), classes);
+      }
+
+      target.setModifiers(Modifier.setPublic(target.getModifiers()));
+    } catch (NotFoundException | ClassNotFoundException | CannotCompileException exception) {
+      throw new ClassTransformException(exception);
+    }
+  }
+
+  private String buildParameters(CtClass[] parameters) {
+    StringBuilder builder = new StringBuilder();
+    for (int i = 0; i < parameters.length; i++) {
+      CtClass parameter = parameters[i];
+      builder.append(parameter.getName()).append(" _").append(i);
+
+      if (i != parameters.length - 1) {
+        builder.append(',');
+      }
+    }
+    return builder.toString();
+  }
+}

--- a/transform/shadow/src/internal/java/net/flintmc/transform/shadow/internal/handler/defaults/ShadowSetterHandler.java
+++ b/transform/shadow/src/internal/java/net/flintmc/transform/shadow/internal/handler/defaults/ShadowSetterHandler.java
@@ -1,0 +1,108 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.transform.shadow.internal.handler.defaults;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.CtField;
+import javassist.CtMethod;
+import javassist.Modifier;
+import javassist.NotFoundException;
+import net.flintmc.processing.autoload.AnnotationMeta;
+import net.flintmc.transform.exceptions.ClassTransformException;
+import net.flintmc.transform.shadow.FieldSetter;
+import net.flintmc.transform.shadow.internal.ShadowHelper;
+import net.flintmc.transform.shadow.internal.handler.RegisterShadowHandler;
+import net.flintmc.transform.shadow.internal.handler.ShadowHandler;
+import net.flintmc.util.mappings.ClassMapping;
+import net.flintmc.util.mappings.ClassMappingProvider;
+import net.flintmc.util.mappings.FieldMapping;
+
+@Singleton
+@RegisterShadowHandler(value = FieldSetter.class, priority = 4)
+public class ShadowSetterHandler implements ShadowHandler<FieldSetter> {
+
+  private final ClassMappingProvider mappingProvider;
+  private final ShadowHelper helper;
+
+  @Inject
+  private ShadowSetterHandler(ClassMappingProvider mappingProvider, ShadowHelper helper) {
+    this.mappingProvider = mappingProvider;
+    this.helper = helper;
+  }
+
+  @Override
+  public void transform(
+      CtClass shadowInterface, CtClass implementation, AnnotationMeta<FieldSetter> meta)
+      throws ClassTransformException {
+    try {
+      FieldSetter fieldSetter = meta.getAnnotation();
+      CtMethod method = this.helper.getLocation(meta.getIdentifier());
+
+      CtClass[] parameters = method.getParameterTypes();
+      if (parameters.length != 1) {
+        throw new IllegalArgumentException(
+            "Setter " + method + " must have one arguments.");
+      }
+      if (method.getReturnType() != CtClass.voidType) {
+        throw new IllegalStateException(
+            "Return type for " + method + " must be void");
+      }
+
+      String fieldName = this.mapFieldName(implementation.getName(), fieldSetter.value());
+      CtField field = implementation.getField(fieldName);
+
+      if (Modifier.isFinal(field.getModifiers())) {
+        field.setModifiers(field.getModifiers() & ~Modifier.FINAL);
+      }
+
+      CtMethod existingMethod = this.helper.getMethod(implementation, method.getName(), parameters);
+      if (existingMethod != null) {
+        if (!Modifier.isPublic(existingMethod.getModifiers())) {
+          existingMethod.setModifiers(Modifier.setPublic(existingMethod.getModifiers()));
+        }
+      } else {
+        implementation.addMethod(
+            CtMethod.make(
+                String.format(
+                    "public void %s(%s arg){this.%s = arg;}",
+                    method.getName(), parameters[0].getName(),
+                    fieldName),
+                implementation));
+      }
+    } catch (NotFoundException | ClassNotFoundException | CannotCompileException exception) {
+      throw new ClassTransformException(exception);
+    }
+  }
+
+  private String mapFieldName(String className, String fieldName) {
+    ClassMapping classMapping = this.mappingProvider.get(className);
+    if (classMapping != null) {
+      FieldMapping fieldMapping = classMapping.getField(fieldName);
+      if (fieldMapping != null) {
+        return fieldMapping.getName();
+      }
+    }
+
+    return fieldName;
+  }
+}

--- a/transform/shadow/src/main/java/net/flintmc/transform/shadow/MethodProxy.java
+++ b/transform/shadow/src/main/java/net/flintmc/transform/shadow/MethodProxy.java
@@ -40,6 +40,4 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @DetectableAnnotation(requiresParent = true)
 public @interface MethodProxy {
-
-  String value() default "";
 }

--- a/util/mapping/src/main/java/net/flintmc/util/mappings/MethodMapping.java
+++ b/util/mapping/src/main/java/net/flintmc/util/mappings/MethodMapping.java
@@ -72,8 +72,13 @@ public final class MethodMapping extends BaseMapping {
     return obfuscatedDescriptor;
   }
 
+  /**
+   * Get the obfuscated or deobfuscated method descriptor, depending on {@link #isObfuscated()}.
+   *
+   * @return An obfuscated or deobfuscated method descriptor
+   */
   public String getDescriptor() {
-    return this.isObfuscated() ? this.obfuscatedDescriptor : this.obfuscatedDescriptor;
+    return this.isObfuscated() ? this.obfuscatedDescriptor : this.deobfuscatedDescriptor;
   }
 
   /**

--- a/util/mapping/src/main/java/net/flintmc/util/mappings/utils/RemappingMethodLocationResolver.java
+++ b/util/mapping/src/main/java/net/flintmc/util/mappings/utils/RemappingMethodLocationResolver.java
@@ -37,7 +37,6 @@ public class RemappingMethodLocationResolver {
 
   public CtMethod getLocation(String owner, String name, String[] parameters) {
     try {
-
       String[] mappedParamNames = new String[parameters.length];
 
       for (int i = 0; i < mappedParamNames.length; i++) {


### PR DESCRIPTION
This PR fixes:
- MethodMapping#getDescriptor returned the obfuscated descriptor even in the dev environment (and thus fixes crashes in the dev environment)
- Wrong MethodProxy method descriptors of the shadow service in the obfuscated environment
- Classes from packages haven't been reobfuscated, only the classes from Flint itself
- Methods from the Implementations of the ResourceLocation interface have been renamed because their obfuscated names are different and therefore they didn't exist anymore and threw AbstractMethodErrors