### PR TITLE
Setup Unittesting

### DIFF
--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -34,5 +34,8 @@ jobs:
       - name: Check for license headers
         run: ./gradlew checkLicenses
 
+      - name: Run unit tests
+        run: ./gradlew test
+
       - name: Build with Gradle
         run: ./gradlew build --full-stacktrace

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,13 @@ subprojects {
             options.isFork = true
         }
 
+        tasks.test {
+            useJUnitPlatform()
+            testLogging {
+                events("passed", "skipped", "failed")
+            }
+        }
+
         license {
             header = rootProject.file("LICENSE-HEADER")
             include("**/*.java")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -83,6 +83,7 @@ defineModule("util:mapping")
 defineModule("util:mojang")
 defineModule("util:session-service")
 defineModule("util:task-executor")
+defineModule("util:unit-testing")
 
 defineModule("minecraft:minecraft-1-15-2")
 defineModule("minecraft:minecraft-1-16-5")

--- a/util/task-executor/src/test/java/net/flintmc/util/taskexecutor/TaskExecutorTest.java
+++ b/util/task-executor/src/test/java/net/flintmc/util/taskexecutor/TaskExecutorTest.java
@@ -1,0 +1,99 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.util.taskexecutor;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+import com.google.inject.Provides;
+import net.flintmc.mcapi.event.TickEvent;
+import net.flintmc.mcapi.event.TickEvent.Type;
+import net.flintmc.util.taskexecutor.internal.DefaultTaskExecutor;
+import net.flintmc.util.unittesting.FlintTest;
+import net.flintmc.util.unittesting.RandomInt;
+import net.flintmc.util.unittesting.RandomInt.Range;
+import org.junit.jupiter.api.Test;
+import java.util.concurrent.ExecutorService;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+@FlintTest
+public class TaskExecutorTest extends AbstractModule {
+
+  @Inject
+  DefaultTaskExecutor taskExecutor;
+
+  @Test
+  public void testTaskScheduled() {
+    Task task = this.mockTask(10);
+    this.taskExecutor.schedule(task);
+    assertTrue(this.taskExecutor.getTasks().contains(task));
+    assertTrue(this.taskExecutor.getSyncTasks().contains(task));
+  }
+
+  @Test
+  public void testTaskTicksDecrease(@RandomInt(Range.POSITIVE) int ticks) {
+    ticks++;
+
+    TickEvent tickEvent = mock(TickEvent.class);
+    when(tickEvent.getType()).thenReturn(Type.GENERAL);
+
+    Task task = mockTask(ticks);
+
+    this.taskExecutor.schedule(task);
+    taskExecutor.onTick(tickEvent);
+
+    verify(task).setTicksToStart(ticks - 1);
+  }
+
+  @Test
+  public void testTaskExecution() {
+    TickEvent tickEvent = mock(TickEvent.class);
+    when(tickEvent.getType()).thenReturn(Type.GENERAL);
+
+    Task task = mockTask(0);
+    this.taskExecutor.schedule(task);
+    this.taskExecutor.onTick(tickEvent);
+
+    verify(task, atLeastOnce()).run();
+    verify(task, atMostOnce()).run();
+  }
+
+  private Task mockTask(int ticks) {
+    Task task = mock(Task.class);
+    when(task.getTicksToStart()).thenReturn(ticks);
+    when(task.getInterval()).thenReturn(0);
+    when(task.isAsync()).thenReturn(false);
+    when(task.isRepeating()).thenReturn(false);
+    when(task.isScheduled()).thenReturn(false);
+    return task;
+  }
+
+  @Provides
+  public Task.Factory provideTaskFactory() {
+    return mock(Task.Factory.class);
+  }
+
+  @Provides
+  public ExecutorService provideExecutorService() {
+    return mock(ExecutorService.class);
+  }
+
+}

--- a/util/unit-testing/build.gradle.kts
+++ b/util/unit-testing/build.gradle.kts
@@ -23,18 +23,10 @@ plugins {
 
 group = "net.flintmc"
 
-flint {
-}
-
 dependencies {
-    annotationProcessor(project(":annotation-processing:annotation-processing-autoload"))
-    internalAnnotationProcessor(project(":annotation-processing:annotation-processing-autoload"))
-
-    api(project(":framework:framework-eventbus"))
-    api(project(":framework:framework-stereotype"))
-    api(project(":mcapi"))
-    api(project(":transform:transform-hook"))
-
-    testImplementation(project(":util:util-unit-testing"))
-    testImplementation(project(":util:util-task-executor", "internal"))
+    api(platform("org.junit:junit-bom:5.7.0"))
+    api("org.junit.jupiter", "junit-jupiter", "5.7.0")
+    api("org.junit.jupiter", "junit-jupiter-api", "5.7.0")
+    api("com.google.inject", "guice", "4.2.0")
+    api("org.mockito:mockito-core:3.7.7")
 }

--- a/util/unit-testing/src/main/java/net/flintmc/util/unittesting/FlintJunitExtension.java
+++ b/util/unit-testing/src/main/java/net/flintmc/util/unittesting/FlintJunitExtension.java
@@ -1,0 +1,89 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.util.unittesting;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import java.util.Optional;
+import java.util.Random;
+import net.flintmc.util.unittesting.RandomInt.Range;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestInstanceFactory;
+import org.junit.jupiter.api.extension.TestInstanceFactoryContext;
+import org.junit.jupiter.api.extension.TestInstantiationException;
+
+public class FlintJunitExtension implements TestInstanceFactory,
+    ParameterResolver {
+
+
+  @Override
+  public Object createTestInstance(TestInstanceFactoryContext factoryContext,
+      ExtensionContext extensionContext) throws TestInstantiationException {
+    try {
+      Object instance = factoryContext.getTestClass().newInstance();
+      if (instance instanceof AbstractModule) {
+        Injector injector = Guice.createInjector((AbstractModule) instance);
+        injector.injectMembers(instance);
+      }
+      return instance;
+    } catch (InstantiationException | IllegalAccessException e) {
+      e.printStackTrace();
+    }
+    return null;
+  }
+
+  @Override
+  public boolean supportsParameter(ParameterContext parameterContext,
+      ExtensionContext extensionContext) throws ParameterResolutionException {
+    return parameterContext.isAnnotated(RandomInt.class) && parameterContext
+        .getParameter().getType().equals(int.class);
+  }
+
+  @Override
+  public Object resolveParameter(ParameterContext parameterContext,
+      ExtensionContext extensionContext) throws ParameterResolutionException {
+
+    Random random = extensionContext.getRoot().getStore(Namespace.GLOBAL)
+        .getOrComputeIfAbsent(Random.class);
+
+    Optional<RandomInt> optRandom = parameterContext
+        .findAnnotation(RandomInt.class);
+    if (!optRandom.isPresent()) {
+      throw new ParameterResolutionException(
+          "Parameter is not annotated with @RandomInt!");
+    }
+
+    RandomInt annotation = optRandom.get();
+
+    if (annotation.value() == Range.NEGATIVE) {
+      return -(random.nextInt(Integer.MAX_VALUE - 2) + 1);
+    } else if (annotation.value() == Range.POSITIVE) {
+      return random.nextInt(Integer.MAX_VALUE - 2);
+    } else {
+      return random.nextBoolean() ? -(random.nextInt(Integer.MAX_VALUE - 3) + 1)
+          : random.nextInt(Integer.MAX_VALUE - 2);
+    }
+  }
+}

--- a/util/unit-testing/src/main/java/net/flintmc/util/unittesting/FlintTest.java
+++ b/util/unit-testing/src/main/java/net/flintmc/util/unittesting/FlintTest.java
@@ -17,24 +17,17 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-plugins {
-    id("java-library")
-}
+package net.flintmc.util.unittesting;
 
-group = "net.flintmc"
+import org.junit.jupiter.api.extension.ExtendWith;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-flint {
-}
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(FlintJunitExtension.class)
+public @interface FlintTest {
 
-dependencies {
-    annotationProcessor(project(":annotation-processing:annotation-processing-autoload"))
-    internalAnnotationProcessor(project(":annotation-processing:annotation-processing-autoload"))
-
-    api(project(":framework:framework-eventbus"))
-    api(project(":framework:framework-stereotype"))
-    api(project(":mcapi"))
-    api(project(":transform:transform-hook"))
-
-    testImplementation(project(":util:util-unit-testing"))
-    testImplementation(project(":util:util-task-executor", "internal"))
 }

--- a/util/unit-testing/src/main/java/net/flintmc/util/unittesting/RandomInt.java
+++ b/util/unit-testing/src/main/java/net/flintmc/util/unittesting/RandomInt.java
@@ -17,24 +17,21 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-plugins {
-    id("java-library")
-}
+package net.flintmc.util.unittesting;
 
-group = "net.flintmc"
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-flint {
-}
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface RandomInt {
 
-dependencies {
-    annotationProcessor(project(":annotation-processing:annotation-processing-autoload"))
-    internalAnnotationProcessor(project(":annotation-processing:annotation-processing-autoload"))
+  Range value() default Range.ALL;
 
-    api(project(":framework:framework-eventbus"))
-    api(project(":framework:framework-stereotype"))
-    api(project(":mcapi"))
-    api(project(":transform:transform-hook"))
+  enum Range {
+    POSITIVE, NEGATIVE, ALL
+  }
 
-    testImplementation(project(":util:util-unit-testing"))
-    testImplementation(project(":util:util-task-executor", "internal"))
 }


### PR DESCRIPTION
- sets up unit testing with JUnit 5 (jupiter)
- provides a simple JUnit extension:
  - Annotate Testclass with `@FlintTest` and extends `AbstractModule` to use `@Provides` and `configure()` to provide mocked interface implementations and use Field injections
  - Annotate int parameters int test methods with `@RandomInt` to inject a random integer (only when test class is annotated with `@FlintTest`)
- Adds `./gradlew test` to CI pipeline