### PR TITLE
World stats api

### DIFF
--- a/mcapi/build.gradle.kts
+++ b/mcapi/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     api(project(":framework:framework-inject"))
     api(project(":framework:framework-stereotype"))
     api(project(":framework:framework-config"))
+    api(project(":framework:framework-data-generation"))
 
     api(project(":transform:transform-hook"))
     api(project(":transform:transform-shadow"))

--- a/mcapi/src/internal/java/net/flintmc/mcapi/internal/world/stats/DefaultItemWorldStat.java
+++ b/mcapi/src/internal/java/net/flintmc/mcapi/internal/world/stats/DefaultItemWorldStat.java
@@ -1,0 +1,68 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.internal.world.stats;
+
+import java.util.Map;
+import net.flintmc.framework.inject.assisted.Assisted;
+import net.flintmc.framework.inject.assisted.AssistedInject;
+import net.flintmc.framework.inject.implement.Implement;
+import net.flintmc.mcapi.items.type.ItemType;
+import net.flintmc.mcapi.world.stats.StatsCategory;
+import net.flintmc.mcapi.world.stats.value.ItemWorldStat;
+
+@Implement(ItemWorldStat.class)
+public class DefaultItemWorldStat implements ItemWorldStat {
+
+  private final StatsCategory category;
+  private final ItemType item;
+  private final Map<ItemStatType, Integer> values;
+  private final Map<ItemStatType, String> formattedValues;
+
+  @AssistedInject
+  private DefaultItemWorldStat(
+      @Assisted("category") StatsCategory category, @Assisted("item") ItemType item,
+      @Assisted("values") Map<ItemStatType, Integer> values,
+      @Assisted("formattedValues") Map<ItemStatType, String> formattedValues) {
+    this.category = category;
+    this.item = item;
+    this.values = values;
+    this.formattedValues = formattedValues;
+  }
+
+  @Override
+  public StatsCategory getCategory() {
+    return this.category;
+  }
+
+  @Override
+  public ItemType getItem() {
+    return this.item;
+  }
+
+  @Override
+  public int getValue(ItemStatType type) {
+    return this.values.getOrDefault(type, 0);
+  }
+
+  @Override
+  public String getFormattedValue(ItemStatType type) {
+    return this.formattedValues.getOrDefault(type, "-");
+  }
+}

--- a/mcapi/src/main/java/net/flintmc/mcapi/entity/type/EntityType.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/entity/type/EntityType.java
@@ -30,6 +30,11 @@ import net.flintmc.mcapi.entity.EntitySize;
  */
 public interface EntityType {
 
+  /**
+   * Retrieves the display name of this entity type, usually a translation component.
+   *
+   * @return The non-null display name of this entity type
+   */
   ChatComponent getDisplayName();
 
   /**
@@ -83,6 +88,7 @@ public interface EntityType {
     /**
      * Creates a new {@link EntityType} by the given parameters.
      *
+     * @param displayName           The non-null display name of this entity type.
      * @param classification        The classifications for an entity type.
      * @param serializable          Whether the entity type if serializable.
      * @param summonable            Whether the entity type is summonable.

--- a/mcapi/src/main/java/net/flintmc/mcapi/entity/type/EntityType.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/entity/type/EntityType.java
@@ -21,6 +21,7 @@ package net.flintmc.mcapi.entity.type;
 
 import net.flintmc.framework.inject.assisted.Assisted;
 import net.flintmc.framework.inject.assisted.AssistedFactory;
+import net.flintmc.mcapi.chat.component.ChatComponent;
 import net.flintmc.mcapi.entity.Entity;
 import net.flintmc.mcapi.entity.EntitySize;
 
@@ -28,6 +29,8 @@ import net.flintmc.mcapi.entity.EntitySize;
  * Represents the entity type.
  */
 public interface EntityType {
+
+  ChatComponent getDisplayName();
 
   /**
    * Retrieves the classification of this entity type.
@@ -89,6 +92,7 @@ public interface EntityType {
      * @return The created entity type.
      */
     EntityType create(
+        @Assisted("displayName") ChatComponent displayName,
         @Assisted("classification") Entity.Classification classification,
         @Assisted("serializable") boolean serializable,
         @Assisted("summonable") boolean summonable,

--- a/mcapi/src/main/java/net/flintmc/mcapi/entity/type/EntityTypeBuilder.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/entity/type/EntityTypeBuilder.java
@@ -29,6 +29,12 @@ import net.flintmc.mcapi.entity.Entity;
  */
 public interface EntityTypeBuilder {
 
+  /**
+   * Sets the display name of the entity type
+   *
+   * @param displayName The non-null display name of the entity type.
+   * @return This builder, for chaining.
+   */
   EntityTypeBuilder displayName(ChatComponent displayName);
 
   /**

--- a/mcapi/src/main/java/net/flintmc/mcapi/entity/type/EntityTypeBuilder.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/entity/type/EntityTypeBuilder.java
@@ -21,12 +21,15 @@ package net.flintmc.mcapi.entity.type;
 
 import net.flintmc.framework.inject.assisted.Assisted;
 import net.flintmc.framework.inject.assisted.AssistedFactory;
+import net.flintmc.mcapi.chat.component.ChatComponent;
 import net.flintmc.mcapi.entity.Entity;
 
 /**
  * Represents a builder to built entity types.
  */
 public interface EntityTypeBuilder {
+
+  EntityTypeBuilder displayName(ChatComponent displayName);
 
   /**
    * Sets the size of the entity type.

--- a/mcapi/src/main/java/net/flintmc/mcapi/items/inventory/event/InventoryUpdateSlotEvent.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/items/inventory/event/InventoryUpdateSlotEvent.java
@@ -29,8 +29,8 @@ import net.flintmc.mcapi.items.ItemStack;
 import net.flintmc.mcapi.items.inventory.Inventory;
 
 /**
- * This event will be fired when an item in the inventory gets updated. It will only be fired in
- * both the {@link Phase#PRE} and {@link Phase#POST} phases.
+ * This event will be fired when an item in the inventory gets updated. It will be fired in both the
+ * {@link Phase#PRE} and {@link Phase#POST} phases.
  *
  * @see Subscribe
  */

--- a/mcapi/src/main/java/net/flintmc/mcapi/items/mapper/MinecraftItemMapper.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/items/mapper/MinecraftItemMapper.java
@@ -21,6 +21,7 @@ package net.flintmc.mcapi.items.mapper;
 
 import net.flintmc.mcapi.items.ItemRegistry;
 import net.flintmc.mcapi.items.ItemStack;
+import net.flintmc.mcapi.items.type.ItemType;
 
 /**
  * A mapper between the Flint {@link ItemStack} and the Minecraft ItemStack.
@@ -47,4 +48,9 @@ public interface MinecraftItemMapper {
    *                              minecraft.
    */
   Object toMinecraft(ItemStack stack) throws ItemMappingException;
+
+  ItemType fromMinecraftType(Object handle) throws ItemMappingException;
+
+  Object toMinecraftType(ItemType type) throws ItemMappingException;
+
 }

--- a/mcapi/src/main/java/net/flintmc/mcapi/server/event/PacketEvent.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/server/event/PacketEvent.java
@@ -31,13 +31,11 @@ import net.flintmc.mcapi.server.status.ServerStatus;
 
 /**
  * This event will be fired whenever a Packet is sent/received to/from a server or in singleplayer
- * to the integrated server. It will be fired in the {@link Phase#PRE} and {@link Phase#POST} phases
- * (for the direction {@link net.flintmc.mcapi.event.DirectionalEvent.Direction#RECEIVE} only in the
- * phase {@link Phase#PRE}), but cancellation will only have an effect in the {@link Phase#PRE}
- * phase.
+ * to the integrated server. It will be fired in the {@link Phase#PRE} and {@link Phase#POST}
+ * phases, but cancellation will only have an effect in the {@link Phase#PRE} phase.
  *
  * <p>This event should only be used if really necessary as it is completely version-specific, for
- * some things there are there separate events that are not version-specific.
+ * some things there are separate events that are not version-specific.
  *
  * @see Subscribe
  */

--- a/mcapi/src/main/java/net/flintmc/mcapi/server/event/PacketEvent.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/server/event/PacketEvent.java
@@ -31,8 +31,10 @@ import net.flintmc.mcapi.server.status.ServerStatus;
 
 /**
  * This event will be fired whenever a Packet is sent/received to/from a server or in singleplayer
- * to the integrated server. It will be fired in the {@link Phase#PRE} and {@link Phase#POST}
- * phases, but cancellation will only have an effect in the {@link Phase#PRE} phase.
+ * to the integrated server. It will be fired in the {@link Phase#PRE} and {@link Phase#POST} phases
+ * (for the direction {@link net.flintmc.mcapi.event.DirectionalEvent.Direction#RECEIVE} only in the
+ * phase {@link Phase#PRE}), but cancellation will only have an effect in the {@link Phase#PRE}
+ * phase.
  *
  * <p>This event should only be used if really necessary as it is completely version-specific, for
  * some things there are there separate events that are not version-specific.

--- a/mcapi/src/main/java/net/flintmc/mcapi/world/stats/StatsCategory.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/world/stats/StatsCategory.java
@@ -21,21 +21,42 @@ package net.flintmc.mcapi.world.stats;
 
 import net.flintmc.framework.generation.annotation.DataFactory;
 import net.flintmc.framework.generation.annotation.TargetDataField;
-import net.flintmc.framework.inject.assisted.Assisted;
-import net.flintmc.framework.inject.assisted.AssistedFactory;
 import net.flintmc.mcapi.chat.component.ChatComponent;
 
+/**
+ * Category of stats that contains more information about a {@link WorldStatType}.
+ */
 public interface StatsCategory {
 
+  /**
+   * Retrieves the {@link WorldStatType} that identifies this category.
+   *
+   * @return The non-null world stat type of this category
+   */
   @TargetDataField("type")
   WorldStatType getType();
 
+  /**
+   * Retrieves the display name of this category as it would be displayed in the menu.
+   *
+   * @return The non-null display name of this category
+   */
   @TargetDataField("displayName")
   ChatComponent getDisplayName();
 
+  /**
+   * Factory for the {@link StatsCategory}.
+   */
   @DataFactory(StatsCategory.class)
   interface Factory {
 
+    /**
+     * Creates a new {@link StatsCategory} for the given type and display name.
+     *
+     * @param type        The non-null type that identifies this category
+     * @param displayName The non-null display name of the new category
+     * @return The new non-null {@link StatsCategory}
+     */
     StatsCategory create(
         @TargetDataField("type") WorldStatType type,
         @TargetDataField("displayName") ChatComponent displayName);

--- a/mcapi/src/main/java/net/flintmc/mcapi/world/stats/StatsCategory.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/world/stats/StatsCategory.java
@@ -1,0 +1,44 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.world.stats;
+
+import net.flintmc.framework.generation.annotation.DataFactory;
+import net.flintmc.framework.generation.annotation.TargetDataField;
+import net.flintmc.framework.inject.assisted.Assisted;
+import net.flintmc.framework.inject.assisted.AssistedFactory;
+import net.flintmc.mcapi.chat.component.ChatComponent;
+
+public interface StatsCategory {
+
+  @TargetDataField("type")
+  WorldStatType getType();
+
+  @TargetDataField("displayName")
+  ChatComponent getDisplayName();
+
+  @DataFactory(StatsCategory.class)
+  interface Factory {
+
+    StatsCategory create(
+        @TargetDataField("type") WorldStatType type,
+        @TargetDataField("displayName") ChatComponent displayName);
+  }
+
+}

--- a/mcapi/src/main/java/net/flintmc/mcapi/world/stats/WorldStatType.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/world/stats/WorldStatType.java
@@ -19,10 +19,32 @@
 
 package net.flintmc.mcapi.world.stats;
 
+import net.flintmc.mcapi.world.stats.value.GeneralWorldStat;
+import net.flintmc.mcapi.world.stats.value.ItemWorldStat;
+import net.flintmc.mcapi.world.stats.value.MobWorldStat;
+import net.flintmc.mcapi.world.stats.value.WorldStat;
+
+/**
+ * Types of stats for the statistics of a player in a world.
+ */
 public enum WorldStatType {
 
+  /**
+   * The {@link WorldStat}s will be an instance of {@link GeneralWorldStat} and contain stuff like
+   * the number of games quit, distance walked.
+   */
   GENERAL,
+
+  /**
+   * The {@link WorldStat}s will be an instance of {@link ItemWorldStat} and contain stuff like the
+   * number of items broken and picked up.
+   */
   ITEM,
+
+  /**
+   * The {@link WorldStat}s will be an instance of {@link MobWorldStat} and contain the number of
+   * kills for each entity type by the player and the mob.
+   */
   MOB;
 
 }

--- a/mcapi/src/main/java/net/flintmc/mcapi/world/stats/WorldStatType.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/world/stats/WorldStatType.java
@@ -1,0 +1,28 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.world.stats;
+
+public enum WorldStatType {
+
+  GENERAL,
+  ITEM,
+  MOB;
+
+}

--- a/mcapi/src/main/java/net/flintmc/mcapi/world/stats/WorldStats.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/world/stats/WorldStats.java
@@ -24,17 +24,44 @@ import net.flintmc.framework.generation.annotation.DataFactory;
 import net.flintmc.framework.generation.annotation.TargetDataField;
 import net.flintmc.mcapi.world.stats.value.WorldStat;
 
+/**
+ * Represents statistics from a specific timestamp per player in a world.
+ */
 public interface WorldStats {
 
+  /**
+   * Retrieves the timestamp when this stats object has been created in milliseconds.
+   *
+   * @return The timestamp in milliseconds
+   * @see System#currentTimeMillis()
+   */
   @TargetDataField("timestamp")
   long getTimestamp();
 
+  /**
+   * Retrieves the stats from this stats object mapped from its corresponding {@link
+   * WorldStatType}.
+   *
+   * @return The non-null map containing every stat per world stat type
+   */
   @TargetDataField("stats")
   Multimap<WorldStatType, WorldStat> getStats();
 
+  /**
+   * Factory for the {@link WorldStats}.
+   */
   @DataFactory(WorldStats.class)
   interface Factory {
 
+    /**
+     * Creates a new {@link WorldStats} object with the given timestamp and stats.
+     *
+     * @param timestamp The current timestamp which represents the timestamp of the creation of the
+     *                  new object
+     * @param stats     The non-null map containing every stat mapped from its corresponding {@link
+     *                  WorldStatType}
+     * @return The new non-null {@link WorldStats} object
+     */
     WorldStats create(
         @TargetDataField("timestamp") long timestamp,
         @TargetDataField("stats") Multimap<WorldStatType, WorldStat> stats);

--- a/mcapi/src/main/java/net/flintmc/mcapi/world/stats/WorldStats.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/world/stats/WorldStats.java
@@ -1,0 +1,44 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.world.stats;
+
+import com.google.common.collect.Multimap;
+import net.flintmc.framework.generation.annotation.DataFactory;
+import net.flintmc.framework.generation.annotation.TargetDataField;
+import net.flintmc.mcapi.world.stats.value.WorldStat;
+
+public interface WorldStats {
+
+  @TargetDataField("timestamp")
+  long getTimestamp();
+
+  @TargetDataField("stats")
+  Multimap<WorldStatType, WorldStat> getStats();
+
+  @DataFactory(WorldStats.class)
+  interface Factory {
+
+    WorldStats create(
+        @TargetDataField("timestamp") long timestamp,
+        @TargetDataField("stats") Multimap<WorldStatType, WorldStat> stats);
+
+  }
+
+}

--- a/mcapi/src/main/java/net/flintmc/mcapi/world/stats/WorldStatsProvider.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/world/stats/WorldStatsProvider.java
@@ -19,10 +19,15 @@
 
 package net.flintmc.mcapi.world.stats;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public interface WorldStatsProvider {
 
-  CompletableFuture<WorldStats> requestStats();
+  WorldStats getCurrentStats();
+
+  CompletableFuture<WorldStats> requestStatsUpdate();
+
+  Map<WorldStatType, StatsCategory> getCategories();
 
 }

--- a/mcapi/src/main/java/net/flintmc/mcapi/world/stats/WorldStatsProvider.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/world/stats/WorldStatsProvider.java
@@ -1,0 +1,28 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.world.stats;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface WorldStatsProvider {
+
+  CompletableFuture<WorldStats> requestStats();
+
+}

--- a/mcapi/src/main/java/net/flintmc/mcapi/world/stats/WorldStatsProvider.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/world/stats/WorldStatsProvider.java
@@ -22,12 +22,38 @@ package net.flintmc.mcapi.world.stats;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Provider to get the {@link WorldStats} from a server.
+ */
 public interface WorldStatsProvider {
 
+  /**
+   * Retrieves the current stats from the last time the server sent them or empty stats if the
+   * server never sent them, though the timestamp will still be the one from the first invocation of
+   * this method when the server never sent them.
+   * <p>
+   * For this to be changed {@link #requestStatsUpdate()} doesn't necessarily need to be called,
+   * Minecraft itself can also send the stats on its own.
+   *
+   * @return The non-null stats from the last update from the server or empty stats (still non-null)
+   * if the server never sent something
+   */
   WorldStats getCurrentStats();
 
+  /**
+   * Requests an update of the stats from the server. When received {@link #getCurrentStats()} will
+   * be updated and the retrieved future will be completed. This request won't time out if the
+   * server doesn't send anything.
+   *
+   * @return The non-null future that will be completed when the server sends the response
+   */
   CompletableFuture<WorldStats> requestStatsUpdate();
 
+  /**
+   * Retrieves all available categories mapped from their corresponding {@link WorldStatType}.
+   *
+   * @return The non-null immutable map with all categories
+   */
   Map<WorldStatType, StatsCategory> getCategories();
 
 }

--- a/mcapi/src/main/java/net/flintmc/mcapi/world/stats/event/PlayerStatsUpdateEvent.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/world/stats/event/PlayerStatsUpdateEvent.java
@@ -21,8 +21,21 @@ package net.flintmc.mcapi.world.stats.event;
 
 import net.flintmc.framework.eventbus.event.Event;
 import net.flintmc.framework.eventbus.event.subscribe.Subscribable;
+import net.flintmc.framework.eventbus.event.subscribe.Subscribe;
 import net.flintmc.framework.eventbus.event.subscribe.Subscribe.Phase;
+import net.flintmc.mcapi.world.stats.WorldStats;
+import net.flintmc.mcapi.world.stats.WorldStatsProvider;
 
+/**
+ * This event will be fired when the server sends an update for the {@link WorldStats}, this will
+ * normally be done after the client sent a request which for example can be when {@link
+ * WorldStatsProvider#requestStatsUpdate()} has been invoked.
+ * <p>
+ * It will be fired in both the {@link Phase#PRE} and {@link Phase#POST} phases.
+ *
+ * @see Subscribe
+ */
 @Subscribable({Phase.PRE, Phase.POST})
 public interface PlayerStatsUpdateEvent extends Event {
+
 }

--- a/mcapi/src/main/java/net/flintmc/mcapi/world/stats/event/PlayerStatsUpdateEvent.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/world/stats/event/PlayerStatsUpdateEvent.java
@@ -1,0 +1,28 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.world.stats.event;
+
+import net.flintmc.framework.eventbus.event.Event;
+import net.flintmc.framework.eventbus.event.subscribe.Subscribable;
+import net.flintmc.framework.eventbus.event.subscribe.Subscribe.Phase;
+
+@Subscribable({Phase.PRE, Phase.POST})
+public interface PlayerStatsUpdateEvent extends Event {
+}

--- a/mcapi/src/main/java/net/flintmc/mcapi/world/stats/value/GeneralWorldStat.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/world/stats/value/GeneralWorldStat.java
@@ -1,0 +1,48 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.world.stats.value;
+
+import net.flintmc.framework.generation.annotation.DataFactory;
+import net.flintmc.framework.generation.annotation.TargetDataField;
+import net.flintmc.mcapi.chat.component.ChatComponent;
+import net.flintmc.mcapi.world.stats.StatsCategory;
+
+public interface GeneralWorldStat extends WorldStat {
+
+  @TargetDataField("displayName")
+  ChatComponent getDisplayName();
+
+  @TargetDataField("formattedValue")
+  String getFormattedValue();
+
+  @TargetDataField("value")
+  int getValue();
+
+  @DataFactory(GeneralWorldStat.class)
+  interface Factory {
+
+    GeneralWorldStat create(
+        @TargetDataField("category") StatsCategory category,
+        @TargetDataField("displayName") ChatComponent displayName,
+        @TargetDataField("formattedValue") String formattedValue,
+        @TargetDataField("value") int value);
+  }
+
+}

--- a/mcapi/src/main/java/net/flintmc/mcapi/world/stats/value/GeneralWorldStat.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/world/stats/value/GeneralWorldStat.java
@@ -23,21 +23,53 @@ import net.flintmc.framework.generation.annotation.DataFactory;
 import net.flintmc.framework.generation.annotation.TargetDataField;
 import net.flintmc.mcapi.chat.component.ChatComponent;
 import net.flintmc.mcapi.world.stats.StatsCategory;
+import net.flintmc.mcapi.world.stats.WorldStats;
 
+/**
+ * Represents a simple statistic from the {@link WorldStats} with an integer value.
+ */
 public interface GeneralWorldStat extends WorldStat {
 
+  /**
+   * Retrieves the display name of this statistic.
+   *
+   * @return The non-null display name of this statistic
+   */
   @TargetDataField("displayName")
   ChatComponent getDisplayName();
 
+  /**
+   * Retrieves the {@link #getValue() value} of this statistic formatted, for example for distances
+   * this will be formatted with an "m" (or "cm"/"km", depending on the value) at the end.
+   *
+   * @return The non-null formatted value of this statistic
+   */
   @TargetDataField("formattedValue")
   String getFormattedValue();
 
+  /**
+   * Retrieves the value of this statistic.
+   *
+   * @return The value of this statistic
+   */
   @TargetDataField("value")
   int getValue();
 
+  /**
+   * Factory for the {@link GeneralWorldStat}.
+   */
   @DataFactory(GeneralWorldStat.class)
   interface Factory {
 
+    /**
+     * Creates a new {@link GeneralWorldStat} with the given values.
+     *
+     * @param category       The non-null category of the new statistic
+     * @param displayName    The non-null display name of the new statistic
+     * @param formattedValue The non-null formatted value of the new statistic
+     * @param value          The value of the new statistic
+     * @return The new non-null {@link GeneralWorldStat}
+     */
     GeneralWorldStat create(
         @TargetDataField("category") StatsCategory category,
         @TargetDataField("displayName") ChatComponent displayName,

--- a/mcapi/src/main/java/net/flintmc/mcapi/world/stats/value/ItemWorldStat.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/world/stats/value/ItemWorldStat.java
@@ -24,18 +24,55 @@ import net.flintmc.framework.inject.assisted.Assisted;
 import net.flintmc.framework.inject.assisted.AssistedFactory;
 import net.flintmc.mcapi.items.type.ItemType;
 import net.flintmc.mcapi.world.stats.StatsCategory;
+import net.flintmc.mcapi.world.stats.WorldStats;
 
+/**
+ * Represents a world stat for a specific item/block from the {@link WorldStats}.
+ */
 public interface ItemWorldStat extends WorldStat {
 
+  /**
+   * Retrieves the item that is represented by this statistic.
+   *
+   * @return The non-null item of this statistic
+   */
   ItemType getItem();
 
+  /**
+   * Retrieves the value of this statistic for the given type which is for example the number of
+   * blocks mined of the type of this statistic if the {@link ItemStatType} is {@link
+   * ItemStatType#BLOCK_MINED}.
+   *
+   * @param type The non-null type to get the value for
+   * @return The value out of this statistic or {@code 0} if there is no value for the given type
+   */
   int getValue(ItemStatType type);
 
+  /**
+   * Retrieves the {@link #getValue(ItemStatType) value} for the given type formatted which for
+   * example is "-" if the value is not set and just the value if it is.
+   *
+   * @param type The non-null type to get the value for
+   * @return The formatted value out of this statistic
+   */
   String getFormattedValue(ItemStatType type);
 
+  /**
+   * Factory for the {@link ItemWorldStat}.
+   */
   @AssistedFactory(ItemWorldStat.class)
   interface Factory {
 
+    /**
+     * Creates a new {@link ItemWorldStat} with the given values.
+     *
+     * @param category        The non-null category of the new statistic
+     * @param item            The non-null item of the new statistic
+     * @param values          The non-null values of the new statistic mapped by the given type
+     * @param formattedValues The non-null formatted values of the new statistic mapped by the given
+     *                        type
+     * @return The new non-null {@link ItemWorldStat}
+     */
     ItemWorldStat create(
         @Assisted("category") StatsCategory category,
         @Assisted("item") ItemType item,
@@ -43,12 +80,38 @@ public interface ItemWorldStat extends WorldStat {
         @Assisted("formattedValues") Map<ItemStatType, String> formattedValues);
   }
 
+  /**
+   * An enumeration of all statistics that are counted per item.
+   */
   enum ItemStatType {
+    /**
+     * The number of blocks mined of an item type.
+     */
     BLOCK_MINED,
+
+    /**
+     * The number of items broken of an item type.
+     */
     ITEM_BROKEN,
+
+    /**
+     * The number of items crafted of an item type.
+     */
     ITEM_CRAFTED,
+
+    /**
+     * The number of times an item type has been used (for example to break a bloc with a pickaxe).
+     */
     ITEM_USED,
+
+    /**
+     * The number of items that have been picked up of an item type.
+     */
     ITEM_PICKED_UP,
+
+    /**
+     * The number of items that have been dropped of an item type.
+     */
     ITEM_DROPPED;
   }
 

--- a/mcapi/src/main/java/net/flintmc/mcapi/world/stats/value/ItemWorldStat.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/world/stats/value/ItemWorldStat.java
@@ -1,0 +1,54 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.world.stats.value;
+
+import java.util.Map;
+import net.flintmc.framework.inject.assisted.Assisted;
+import net.flintmc.framework.inject.assisted.AssistedFactory;
+import net.flintmc.mcapi.items.type.ItemType;
+import net.flintmc.mcapi.world.stats.StatsCategory;
+
+public interface ItemWorldStat extends WorldStat {
+
+  ItemType getItem();
+
+  int getValue(ItemStatType type);
+
+  String getFormattedValue(ItemStatType type);
+
+  @AssistedFactory(ItemWorldStat.class)
+  interface Factory {
+
+    ItemWorldStat create(
+        @Assisted("category") StatsCategory category, @Assisted("item") ItemType item,
+        @Assisted("values") Map<ItemStatType, Integer> values,
+        @Assisted("formattedValues") Map<ItemStatType, String> formattedValues);
+  }
+
+  enum ItemStatType {
+    BLOCK_MINED,
+    ITEM_BROKEN,
+    ITEM_CRAFTED,
+    ITEM_USED,
+    ITEM_PICKED_UP,
+    ITEM_DROPPED;
+  }
+
+}

--- a/mcapi/src/main/java/net/flintmc/mcapi/world/stats/value/ItemWorldStat.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/world/stats/value/ItemWorldStat.java
@@ -37,7 +37,8 @@ public interface ItemWorldStat extends WorldStat {
   interface Factory {
 
     ItemWorldStat create(
-        @Assisted("category") StatsCategory category, @Assisted("item") ItemType item,
+        @Assisted("category") StatsCategory category,
+        @Assisted("item") ItemType item,
         @Assisted("values") Map<ItemStatType, Integer> values,
         @Assisted("formattedValues") Map<ItemStatType, String> formattedValues);
   }

--- a/mcapi/src/main/java/net/flintmc/mcapi/world/stats/value/MobWorldStat.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/world/stats/value/MobWorldStat.java
@@ -24,27 +24,74 @@ import net.flintmc.framework.generation.annotation.TargetDataField;
 import net.flintmc.mcapi.chat.component.ChatComponent;
 import net.flintmc.mcapi.entity.type.EntityType;
 import net.flintmc.mcapi.world.stats.StatsCategory;
+import net.flintmc.mcapi.world.stats.WorldStats;
 
+/**
+ * Represents a world stat for the number of kills by and towards a specific entity type from the
+ * {@link WorldStats}.
+ */
 public interface MobWorldStat extends WorldStat {
 
+  /**
+   * Retrieves the entity type that is represented by this statistic.
+   *
+   * @return The non-null entity type of this statistic
+   */
   @TargetDataField("entityType")
   EntityType getEntityType();
 
+  /**
+   * Retrieves the component that represents the number of kills for this entity type.
+   *
+   * @return The non-null component with the number of kills
+   */
   @TargetDataField("killedComponent")
   ChatComponent getKilledComponent();
 
+  /**
+   * Retrieves the component that represents the number of kills by this entity type.
+   *
+   * @return The non-null component with the number of kills
+   */
   @TargetDataField("killedByComponent")
   ChatComponent getKilledByComponent();
 
+  /**
+   * Retrieves the number of entities that have been killed by the player of this entity type.
+   *
+   * @return The number of kills
+   */
   @TargetDataField("killedCount")
   int getKilledCount();
 
+  /**
+   * Retrieves the number of times the player has been killed by an entity of this type.
+   *
+   * @return The number of kills
+   */
   @TargetDataField("killedByCount")
   int getKilledByCount();
 
+  /**
+   * Factory for the {@link MobWorldStat}.
+   */
   @DataFactory(MobWorldStat.class)
   interface Factory {
 
+    /**
+     * Creates a new {@link MobWorldStat}.
+     *
+     * @param category          The non-null category of the new statistic
+     * @param entityType        The non-null entity type of the new statistic
+     * @param killedComponent   The non-null component that represents the number of kills
+     * @param killedByComponent The non-null component that represents the number of kills by the
+     *                          entities of the given entity type
+     * @param killedCount       The number of entities that have been killed by the player of the
+     *                          given entity type
+     * @param killedByCount     The number of times the player has been killed by an entity of the
+     *                          given entity type
+     * @return THe new non-null {@link MobWorldStat}
+     */
     MobWorldStat create(
         @TargetDataField("category") StatsCategory category,
         @TargetDataField("entityType") EntityType entityType,

--- a/mcapi/src/main/java/net/flintmc/mcapi/world/stats/value/MobWorldStat.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/world/stats/value/MobWorldStat.java
@@ -1,0 +1,56 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.world.stats.value;
+
+import net.flintmc.framework.generation.annotation.DataFactory;
+import net.flintmc.framework.generation.annotation.TargetDataField;
+import net.flintmc.mcapi.chat.component.ChatComponent;
+import net.flintmc.mcapi.entity.type.EntityType;
+import net.flintmc.mcapi.world.stats.StatsCategory;
+
+public interface MobWorldStat extends WorldStat {
+
+  @TargetDataField("entityType")
+  EntityType getEntityType();
+
+  @TargetDataField("killedComponent")
+  ChatComponent getKilledComponent();
+
+  @TargetDataField("killedByComponent")
+  ChatComponent getKilledByComponent();
+
+  @TargetDataField("killedCount")
+  int getKilledCount();
+
+  @TargetDataField("killedByCount")
+  int getKilledByCount();
+
+  @DataFactory(MobWorldStat.class)
+  interface Factory {
+
+    MobWorldStat create(
+        @TargetDataField("category") StatsCategory category,
+        @TargetDataField("entityType") EntityType entityType,
+        @TargetDataField("killedComponent") ChatComponent killedComponent,
+        @TargetDataField("killedByComponent") ChatComponent killedByComponent,
+        @TargetDataField("killedCount") int killedCount,
+        @TargetDataField("killedByCount") int killedByCount);
+  }
+}

--- a/mcapi/src/main/java/net/flintmc/mcapi/world/stats/value/WorldStat.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/world/stats/value/WorldStat.java
@@ -21,9 +21,18 @@ package net.flintmc.mcapi.world.stats.value;
 
 import net.flintmc.framework.generation.annotation.TargetDataField;
 import net.flintmc.mcapi.world.stats.StatsCategory;
+import net.flintmc.mcapi.world.stats.WorldStats;
 
+/**
+ * Represents a single statistic value from the {@link WorldStats}.
+ */
 public interface WorldStat {
 
+  /**
+   * Retrieves the category to which this statistic value belongs to.
+   *
+   * @return The non-null category of this statistic value
+   */
   @TargetDataField("category")
   StatsCategory getCategory();
 

--- a/mcapi/src/main/java/net/flintmc/mcapi/world/stats/value/WorldStat.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/world/stats/value/WorldStat.java
@@ -1,0 +1,30 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.world.stats.value;
+
+import net.flintmc.framework.generation.annotation.TargetDataField;
+import net.flintmc.mcapi.world.stats.StatsCategory;
+
+public interface WorldStat {
+
+  @TargetDataField("category")
+  StatsCategory getCategory();
+
+}

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/entity/type/VersionedEntityType.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/entity/type/VersionedEntityType.java
@@ -22,6 +22,7 @@ package net.flintmc.mcapi.v1_15_2.entity.type;
 import net.flintmc.framework.inject.assisted.Assisted;
 import net.flintmc.framework.inject.assisted.AssistedInject;
 import net.flintmc.framework.inject.implement.Implement;
+import net.flintmc.mcapi.chat.component.ChatComponent;
 import net.flintmc.mcapi.entity.Entity;
 import net.flintmc.mcapi.entity.EntitySize;
 import net.flintmc.mcapi.entity.type.EntityType;
@@ -32,6 +33,7 @@ import net.flintmc.mcapi.entity.type.EntityType;
 @Implement(value = EntityType.class, version = "1.15.2")
 public class VersionedEntityType implements EntityType {
 
+  private final ChatComponent displayName;
   private final Entity.Classification classification;
   private final boolean serializable;
   private final boolean summonable;
@@ -41,18 +43,28 @@ public class VersionedEntityType implements EntityType {
 
   @AssistedInject
   private VersionedEntityType(
+      @Assisted("displayName") ChatComponent displayName,
       @Assisted("classification") Entity.Classification classification,
       @Assisted("serializable") boolean serializable,
       @Assisted("summonable") boolean summonable,
       @Assisted("immuneToFire") boolean immuneToFire,
       @Assisted("canSpawnFarFromPlayer") boolean canSpawnFarFromPlayer,
       @Assisted("entitySize") EntitySize entitySize) {
+    this.displayName = displayName;
     this.classification = classification;
     this.serializable = serializable;
     this.summonable = summonable;
     this.immuneToFire = immuneToFire;
     this.canSpawnFarFromPlayer = canSpawnFarFromPlayer;
     this.entitySize = entitySize;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public ChatComponent getDisplayName() {
+    return this.displayName;
   }
 
   /**

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/entity/type/VersionedEntityTypeBuilder.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/entity/type/VersionedEntityTypeBuilder.java
@@ -22,6 +22,7 @@ package net.flintmc.mcapi.v1_15_2.entity.type;
 import net.flintmc.framework.inject.assisted.Assisted;
 import net.flintmc.framework.inject.assisted.AssistedInject;
 import net.flintmc.framework.inject.implement.Implement;
+import net.flintmc.mcapi.chat.component.ChatComponent;
 import net.flintmc.mcapi.entity.Entity;
 import net.flintmc.mcapi.entity.EntitySize;
 import net.flintmc.mcapi.entity.type.EntityType;
@@ -36,6 +37,7 @@ public class VersionedEntityTypeBuilder implements EntityTypeBuilder {
   private final Entity.Classification classification;
   private final EntitySize.Factory entitySizeFactory;
   private final EntityType.Factory entityTypeFactory;
+  private ChatComponent displayName;
   private boolean serializable;
   private boolean summonable;
   private boolean immuneToFire;
@@ -56,6 +58,12 @@ public class VersionedEntityTypeBuilder implements EntityTypeBuilder {
         classification == Entity.Classification.CREATURE
             || classification == Entity.Classification.MISC;
     this.size = entitySizeFactory.create(0.6F, 1.8F, false);
+  }
+
+  @Override
+  public EntityTypeBuilder displayName(ChatComponent displayName) {
+    this.displayName = displayName;
+    return this;
   }
 
   /**
@@ -109,6 +117,7 @@ public class VersionedEntityTypeBuilder implements EntityTypeBuilder {
   @Override
   public EntityType build(String id) {
     return this.entityTypeFactory.create(
+        this.displayName,
         this.classification,
         this.serializable,
         this.summonable,

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/entity/type/VersionedEntityTypeBuilder.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/entity/type/VersionedEntityTypeBuilder.java
@@ -60,6 +60,9 @@ public class VersionedEntityTypeBuilder implements EntityTypeBuilder {
     this.size = entitySizeFactory.create(0.6F, 1.8F, false);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public EntityTypeBuilder displayName(ChatComponent displayName) {
     this.displayName = displayName;

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/entity/type/VersionedEntityTypeMapper.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/entity/type/VersionedEntityTypeMapper.java
@@ -22,6 +22,8 @@ package net.flintmc.mcapi.v1_15_2.entity.type;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import net.flintmc.framework.inject.implement.Implement;
+import net.flintmc.mcapi.chat.builder.TranslationComponentBuilder;
+import net.flintmc.mcapi.chat.builder.TranslationComponentBuilder.Factory;
 import net.flintmc.mcapi.entity.Entity;
 import net.flintmc.mcapi.entity.EntitySize;
 import net.flintmc.mcapi.entity.type.EntityType;
@@ -35,12 +37,15 @@ import net.minecraft.entity.EntityClassification;
 @Implement(value = EntityTypeMapper.class, version = "1.15.2")
 public class VersionedEntityTypeMapper implements EntityTypeMapper {
 
+  private final TranslationComponentBuilder.Factory componentFactory;
   private final EntityType.Factory entityTypeFactory;
   private final EntitySize.Factory entitySizeFactory;
 
   @Inject
   private VersionedEntityTypeMapper(
+      Factory componentFactory,
       EntityType.Factory entityTypeFactory, EntitySize.Factory entitySizeFactory) {
+    this.componentFactory = componentFactory;
     this.entityTypeFactory = entityTypeFactory;
     this.entitySizeFactory = entitySizeFactory;
   }
@@ -60,6 +65,7 @@ public class VersionedEntityTypeMapper implements EntityTypeMapper {
     net.minecraft.entity.EntityType type = (net.minecraft.entity.EntityType) handle;
 
     return this.entityTypeFactory.create(
+        this.componentFactory.newBuilder().translationKey(type.getTranslationKey()).build(),
         this.fromMinecraftEntityClassification(type.getClassification()),
         type.isSerializable(),
         type.isSummonable(),

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/items/mapper/VersionedMinecraftItemMapper.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/items/mapper/VersionedMinecraftItemMapper.java
@@ -51,6 +51,9 @@ public class VersionedMinecraftItemMapper implements MinecraftItemMapper {
     this.metaFactory = metaFactory;
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public ItemStack fromMinecraft(Object handle) throws ItemMappingException {
     if (!(handle instanceof net.minecraft.item.ItemStack)) {
@@ -61,15 +64,7 @@ public class VersionedMinecraftItemMapper implements MinecraftItemMapper {
     }
     net.minecraft.item.ItemStack stack = (net.minecraft.item.ItemStack) handle;
 
-    ResourceLocation resourceLocation = Registry.ITEM.getKey(stack.getItem());
-    NameSpacedKey registryName =
-        NameSpacedKey.of(resourceLocation.getNamespace(), resourceLocation.getPath());
-
-    ItemType type = this.registry.getType(registryName);
-    if (type == null) {
-      throw new ItemMappingException("No item type with the name " + registryName + " found");
-    }
-
+    ItemType type = this.fromMinecraftType(stack.getItem());
     ItemMeta meta = this.metaFactory.createMeta(type);
 
     if (stack.getTag() != null) {
@@ -79,16 +74,14 @@ public class VersionedMinecraftItemMapper implements MinecraftItemMapper {
     return this.itemFactory.createItemStack(type, stack.getCount(), meta);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public Object toMinecraft(ItemStack stack) throws ItemMappingException {
-    Item item =
-        Registry.ITEM
-            .getValue(stack.getType().getResourceLocation().getHandle())
-            .orElseThrow(
-                () ->
-                    new ItemMappingException(
-                        "Unknown item " + stack.getType().getResourceLocation()));
+    Item item = (Item) this.toMinecraftType(stack.getType());
 
+    // Cannot use a lambda because those aren't properly reobfuscated
     net.minecraft.item.ItemStack result =
         new net.minecraft.item.ItemStack(new IItemProvider() {
           @Override
@@ -103,5 +96,31 @@ public class VersionedMinecraftItemMapper implements MinecraftItemMapper {
     }
 
     return result;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public ItemType fromMinecraftType(Object handle) {
+    ResourceLocation resourceLocation = Registry.ITEM.getKey((Item) handle);
+    NameSpacedKey registryName =
+        NameSpacedKey.of(resourceLocation.getNamespace(), resourceLocation.getPath());
+
+    ItemType type = this.registry.getType(registryName);
+    if (type == null) {
+      throw new ItemMappingException("No item type with the name " + registryName + " found");
+    }
+
+    return type;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Object toMinecraftType(ItemType type) {
+    return Registry.ITEM.getValue(type.getResourceLocation().getHandle())
+        .orElseThrow(() -> new ItemMappingException("Unknown item " + type.getResourceLocation()));
   }
 }

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/server/event/PacketEventInjectionTransformer.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/server/event/PacketEventInjectionTransformer.java
@@ -1,0 +1,78 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_15_2.server.event;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.CtField;
+import javassist.CtMethod;
+import javassist.NotFoundException;
+import net.flintmc.framework.inject.InjectedFieldBuilder;
+import net.flintmc.framework.inject.InjectedFieldBuilder.Factory;
+import net.flintmc.transform.hook.Hook.ExecutionTime;
+import net.flintmc.transform.javassist.ClassTransform;
+import net.flintmc.transform.javassist.ClassTransformContext;
+import net.flintmc.transform.javassist.CtClassFilter;
+import net.flintmc.transform.javassist.CtClassFilters;
+import net.flintmc.util.mappings.ClassMappingProvider;
+
+@Singleton
+public class PacketEventInjectionTransformer {
+
+  private final ClassMappingProvider mappingProvider;
+  private final InjectedFieldBuilder.Factory fieldBuilderFactory;
+
+  @Inject
+  private PacketEventInjectionTransformer(
+      ClassMappingProvider mappingProvider, Factory fieldBuilderFactory) {
+    this.mappingProvider = mappingProvider;
+    this.fieldBuilderFactory = fieldBuilderFactory;
+  }
+
+  @ClassTransform(version = "1.15.2")
+  @CtClassFilter(value = CtClassFilters.SUBCLASS_OF, className = "net.minecraft.network.IPacket")
+  public void transformPacket(ClassTransformContext context)
+      throws NotFoundException, CannotCompileException {
+    CtClass packet = context.getCtClass();
+
+    CtClass netHandler = packet.getClassPool()
+        .get(this.mappingProvider.get("net.minecraft.network.INetHandler").getName());
+
+    for (CtMethod method : packet.getDeclaredMethods()) {
+      CtClass[] params = method.getParameterTypes();
+      if (params.length != 1 || !params[0].subtypeOf(netHandler)) {
+        continue;
+      }
+
+      CtField injectorField = fieldBuilderFactory.create()
+          .target(packet)
+          .inject(PacketEventInjector.class)
+          .generate();
+
+      method.insertAfter(
+          String.format("{ %s.processIncomingPacket(new Object[]{$0}, %s.AFTER); }",
+              injectorField.getName(),
+              ExecutionTime.class.getName()));
+      break;
+    }
+  }
+}

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/server/event/PacketEventInjector.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/server/event/PacketEventInjector.java
@@ -24,12 +24,12 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import io.netty.util.concurrent.GenericFutureListener;
 import net.flintmc.framework.eventbus.EventBus;
-import net.flintmc.framework.eventbus.event.subscribe.Subscribe.Phase;
 import net.flintmc.framework.inject.logging.InjectLogger;
 import net.flintmc.framework.stereotype.type.Type;
 import net.flintmc.mcapi.event.DirectionalEvent;
 import net.flintmc.mcapi.server.event.PacketEvent;
 import net.flintmc.transform.hook.Hook;
+import net.flintmc.transform.hook.Hook.ExecutionTime;
 import net.flintmc.transform.hook.HookResult;
 import net.minecraft.network.INetHandler;
 import net.minecraft.network.IPacket;
@@ -57,7 +57,8 @@ public class PacketEventInjector {
       methodName = "processPacket",
       parameters = {@Type(reference = IPacket.class), @Type(reference = INetHandler.class)},
       version = "1.15.2")
-  public HookResult processIncomingPacket(@Named("args") Object[] args) {
+  public HookResult processIncomingPacket(
+      @Named("args") Object[] args, ExecutionTime executionTime) {
     Object packet = args[0];
     ProtocolType type = ProtocolType.getFromPacket((IPacket<?>) packet);
     if (type == null) {
@@ -69,10 +70,7 @@ public class PacketEventInjector {
 
     PacketEvent.ProtocolPhase phase = this.getFlintPhaseFromType(type);
     PacketEvent event = this.eventFactory.create(packet, phase, DirectionalEvent.Direction.RECEIVE);
-    this.eventBus.fireEvent(event, Phase.PRE);
-
-    // Cannot be fired in POST because the processPacket method throws an exception when not
-    // invoked on the main thread
+    this.eventBus.fireEvent(event, executionTime);
 
     return event.isCancelled() ? HookResult.BREAK : HookResult.CONTINUE;
   }

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/server/event/ServerConnectEventInjector.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/server/event/ServerConnectEventInjector.java
@@ -24,6 +24,7 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import net.flintmc.framework.eventbus.EventBus;
 import net.flintmc.framework.eventbus.event.subscribe.PostSubscribe;
+import net.flintmc.framework.eventbus.event.subscribe.PreSubscribe;
 import net.flintmc.framework.eventbus.event.subscribe.Subscribe.Phase;
 import net.flintmc.framework.stereotype.type.Type;
 import net.flintmc.mcapi.event.DirectionalEvent.Direction;
@@ -67,7 +68,7 @@ public class ServerConnectEventInjector {
     this.eventBus.fireEvent(this.eventFactory.create(address), Phase.PRE);
   }
 
-  @PostSubscribe(version = "1.15.2")
+  @PreSubscribe(version = "1.15.2")
   public void handleLoginSuccess(PacketEvent event) {
     if (event.getDirection() != Direction.RECEIVE
         || event.getPhase() != ProtocolPhase.LOGIN

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/world/stats/StatsScreenShadow.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/world/stats/StatsScreenShadow.java
@@ -24,7 +24,6 @@ import net.flintmc.transform.shadow.FieldGetter;
 import net.flintmc.transform.shadow.MethodProxy;
 import net.flintmc.transform.shadow.Shadow;
 import net.minecraft.block.Block;
-import net.minecraft.client.gui.widget.list.ExtendedList;
 import net.minecraft.entity.EntityType;
 import net.minecraft.item.Item;
 import net.minecraft.stats.Stat;
@@ -50,12 +49,8 @@ public interface StatsScreenShadow {
   @MethodProxy
   void initLists();
 
-  @MethodProxy
-  void func_213110_a(ExtendedList<?> list);
-
   default void updateData() {
     this.initLists();
-    this.func_213110_a((ExtendedList<?>) this.getGeneralStats());
   }
 
   @Shadow(value = "net.minecraft.client.gui.screen.StatsScreen$CustomStatsList", version = "1.15.2")

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/world/stats/StatsScreenShadow.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/world/stats/StatsScreenShadow.java
@@ -1,0 +1,114 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_15_2.world.stats;
+
+import java.util.List;
+import net.flintmc.transform.shadow.FieldGetter;
+import net.flintmc.transform.shadow.MethodProxy;
+import net.flintmc.transform.shadow.Shadow;
+import net.minecraft.block.Block;
+import net.minecraft.client.gui.widget.list.ExtendedList;
+import net.minecraft.entity.EntityType;
+import net.minecraft.item.Item;
+import net.minecraft.stats.Stat;
+import net.minecraft.stats.StatType;
+import net.minecraft.stats.StatisticsManager;
+import net.minecraft.util.ResourceLocation;
+
+@Shadow(value = "net.minecraft.client.gui.screen.StatsScreen", version = "1.15.2")
+public interface StatsScreenShadow {
+
+  @FieldGetter("stats")
+  StatisticsManager getStatsManager();
+
+  @FieldGetter("generalStats")
+  GeneralListShadow getGeneralStats();
+
+  @FieldGetter("mobStats")
+  MobListShadow getMobStats();
+
+  @FieldGetter("itemStats")
+  ItemListShadow getItemStats();
+
+  @MethodProxy
+  void initLists();
+
+  @MethodProxy
+  void func_213110_a(ExtendedList<?> list);
+
+  default void updateData() {
+    this.initLists();
+    this.func_213110_a((ExtendedList<?>) this.getGeneralStats());
+  }
+
+  @Shadow(value = "net.minecraft.client.gui.screen.StatsScreen$CustomStatsList", version = "1.15.2")
+  interface GeneralListShadow {
+
+    @SuppressWarnings("unchecked")
+    default List<GeneralStat> getStats() {
+      return (List<GeneralStat>) ((AbstractListShadow) this).getChildren();
+    }
+
+    @Shadow(value = "net.minecraft.client.gui.screen.StatsScreen$CustomStatsList$Entry", version = "1.15.2")
+    interface GeneralStat {
+
+      @FieldGetter("field_214405_b")
+      Stat<ResourceLocation> getStat();
+    }
+  }
+
+  @Shadow(value = "net.minecraft.client.gui.screen.StatsScreen$MobStatsList", version = "1.15.2")
+  interface MobListShadow {
+
+    @SuppressWarnings("unchecked")
+    default List<MobStat> getStats() {
+      return (List<MobStat>) ((AbstractListShadow) this).getChildren();
+    }
+
+    @Shadow(value = "net.minecraft.client.gui.screen.StatsScreen$MobStatsList$Entry", version = "1.15.2")
+    interface MobStat {
+
+      @FieldGetter("field_214411_b")
+      EntityType<?> getEntityType();
+    }
+  }
+
+  @Shadow(value = "net.minecraft.client.gui.screen.StatsScreen$StatsList", version = "1.15.2")
+  interface ItemListShadow {
+
+    @FieldGetter("field_195113_v")
+    List<StatType<Block>> getBlockStatTypes();
+
+    @FieldGetter("field_195114_w")
+    List<StatType<Item>> getItemStatTypes();
+
+    @FieldGetter("field_195116_y")
+    List<Item> getAvailableItems();
+  }
+
+  @Shadow(value = "net.minecraft.client.gui.widget.list.AbstractList", version = "1.15.2")
+  interface AbstractListShadow {
+
+    @FieldGetter("children")
+    List<?> getChildren();
+
+  }
+
+}

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/world/stats/VersionedWorldStatsMapper.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/world/stats/VersionedWorldStatsMapper.java
@@ -20,6 +20,7 @@
 package net.flintmc.mcapi.v1_15_2.world.stats;
 
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -78,6 +79,7 @@ public class VersionedWorldStatsMapper {
   private final StatsCategory generalCategory;
   private final StatsCategory mobCategory;
   private final StatsCategory itemCategory;
+  private final Map<WorldStatType, StatsCategory> categories;
 
   @Inject
   private VersionedWorldStatsMapper(
@@ -101,6 +103,16 @@ public class VersionedWorldStatsMapper {
     this.generalCategory = this.createCategory(WorldStatType.GENERAL, "stat.generalButton");
     this.itemCategory = this.createCategory(WorldStatType.ITEM, "stat.itemsButton");
     this.mobCategory = this.createCategory(WorldStatType.MOB, "stat.mobsButton");
+
+    this.categories = ImmutableMap.of(
+        WorldStatType.GENERAL, this.generalCategory,
+        WorldStatType.ITEM, this.itemCategory,
+        WorldStatType.MOB, this.mobCategory
+    );
+  }
+
+  public Map<WorldStatType, StatsCategory> getCategories() {
+    return this.categories;
   }
 
   public WorldStats map(StatsScreenShadow shadow) {

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/world/stats/VersionedWorldStatsMapper.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/world/stats/VersionedWorldStatsMapper.java
@@ -1,0 +1,211 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_15_2.world.stats;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.HashMap;
+import java.util.Map;
+import net.flintmc.mcapi.chat.builder.TranslationComponentBuilder;
+import net.flintmc.mcapi.chat.component.ChatComponent;
+import net.flintmc.mcapi.entity.type.EntityType;
+import net.flintmc.mcapi.entity.type.EntityTypeMapper;
+import net.flintmc.mcapi.items.mapper.MinecraftItemMapper;
+import net.flintmc.mcapi.items.type.ItemType;
+import net.flintmc.mcapi.v1_15_2.world.stats.StatsScreenShadow.GeneralListShadow.GeneralStat;
+import net.flintmc.mcapi.v1_15_2.world.stats.StatsScreenShadow.ItemListShadow;
+import net.flintmc.mcapi.v1_15_2.world.stats.StatsScreenShadow.MobListShadow.MobStat;
+import net.flintmc.mcapi.world.stats.StatsCategory;
+import net.flintmc.mcapi.world.stats.WorldStatType;
+import net.flintmc.mcapi.world.stats.WorldStats;
+import net.flintmc.mcapi.world.stats.WorldStats.Factory;
+import net.flintmc.mcapi.world.stats.value.GeneralWorldStat;
+import net.flintmc.mcapi.world.stats.value.ItemWorldStat;
+import net.flintmc.mcapi.world.stats.value.ItemWorldStat.ItemStatType;
+import net.flintmc.mcapi.world.stats.value.MobWorldStat;
+import net.flintmc.mcapi.world.stats.value.WorldStat;
+import net.minecraft.block.Block;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.stats.Stat;
+import net.minecraft.stats.StatType;
+import net.minecraft.stats.StatisticsManager;
+import net.minecraft.stats.Stats;
+
+@Singleton
+public class VersionedWorldStatsMapper {
+
+  private static final Map<StatType<?>, ItemStatType> ITEM_STAT_TYPES = new HashMap<>();
+
+  static {
+    ITEM_STAT_TYPES.put(Stats.BLOCK_MINED, ItemStatType.BLOCK_MINED);
+    ITEM_STAT_TYPES.put(Stats.ITEM_BROKEN, ItemStatType.ITEM_BROKEN);
+    ITEM_STAT_TYPES.put(Stats.ITEM_CRAFTED, ItemStatType.ITEM_CRAFTED);
+    ITEM_STAT_TYPES.put(Stats.ITEM_USED, ItemStatType.ITEM_USED);
+    ITEM_STAT_TYPES.put(Stats.ITEM_PICKED_UP, ItemStatType.ITEM_PICKED_UP);
+    ITEM_STAT_TYPES.put(Stats.ITEM_DROPPED, ItemStatType.ITEM_DROPPED);
+  }
+
+  private final WorldStats.Factory statsFactory;
+  private final StatsCategory.Factory categoryFactory;
+  private final GeneralWorldStat.Factory simpleStatFactory;
+  private final MobWorldStat.Factory mobStatFactory;
+  private final ItemWorldStat.Factory itemStatFactory;
+
+  private final TranslationComponentBuilder.Factory componentBuilderFactory;
+  private final EntityTypeMapper entityTypeMapper;
+  private final MinecraftItemMapper itemMapper;
+
+  private final StatsCategory generalCategory;
+  private final StatsCategory mobCategory;
+  private final StatsCategory itemCategory;
+
+  @Inject
+  private VersionedWorldStatsMapper(
+      Factory statsFactory,
+      StatsCategory.Factory categoryFactory,
+      GeneralWorldStat.Factory simpleStatFactory,
+      MobWorldStat.Factory mobStatFactory,
+      ItemWorldStat.Factory itemStatFactory,
+      TranslationComponentBuilder.Factory componentBuilderFactory,
+      EntityTypeMapper entityTypeMapper,
+      MinecraftItemMapper itemMapper) {
+    this.statsFactory = statsFactory;
+    this.componentBuilderFactory = componentBuilderFactory;
+    this.categoryFactory = categoryFactory;
+    this.simpleStatFactory = simpleStatFactory;
+    this.mobStatFactory = mobStatFactory;
+    this.itemStatFactory = itemStatFactory;
+    this.entityTypeMapper = entityTypeMapper;
+    this.itemMapper = itemMapper;
+
+    this.generalCategory = this.createCategory(WorldStatType.GENERAL, "stat.generalButton");
+    this.itemCategory = this.createCategory(WorldStatType.ITEM, "stat.itemsButton");
+    this.mobCategory = this.createCategory(WorldStatType.MOB, "stat.mobsButton");
+  }
+
+  public WorldStats map(StatsScreenShadow shadow) {
+    Multimap<WorldStatType, WorldStat> stats = HashMultimap.create();
+
+    this.buildSimpleStats(stats, shadow);
+    this.buildMobStats(stats, shadow);
+    this.buildItemStats(stats, shadow);
+
+    return this.statsFactory.create(System.currentTimeMillis(), stats);
+  }
+
+  private void buildSimpleStats(
+      Multimap<WorldStatType, WorldStat> target, StatsScreenShadow shadow) {
+    for (GeneralStat stat : shadow.getGeneralStats().getStats()) {
+      int value = shadow.getStatsManager().getValue(stat.getStat());
+      ChatComponent displayName = this.componentBuilderFactory.newBuilder()
+          .translationKey("stat." + stat.getStat().getValue().toString().replace(':', '.'))
+          .build();
+
+      target.put(WorldStatType.GENERAL, this.simpleStatFactory
+          .create(this.generalCategory, displayName, stat.getStat().format(value), value));
+    }
+  }
+
+  private void buildMobStats(Multimap<WorldStatType, WorldStat> target, StatsScreenShadow shadow) {
+    for (MobStat stat : shadow.getMobStats().getStats()) {
+      net.minecraft.entity.EntityType<?> rawEntityType = stat.getEntityType();
+      EntityType entityType = this.entityTypeMapper.fromMinecraftEntityType(rawEntityType);
+
+      int killed = shadow.getStatsManager().getValue(Stats.ENTITY_KILLED.get(rawEntityType));
+      int killedBy = shadow.getStatsManager().getValue(Stats.ENTITY_KILLED_BY.get(rawEntityType));
+      ChatComponent killedComponent = this.buildMobComponent(
+          entityType, Stats.ENTITY_KILLED.getTranslationKey(), true, killed);
+      ChatComponent killedByComponent = this.buildMobComponent(
+          entityType, Stats.ENTITY_KILLED_BY.getTranslationKey(), false, killedBy);
+
+      MobWorldStat worldStat = this.mobStatFactory.create(
+          this.mobCategory, entityType, killedComponent, killedByComponent, killed, killedBy);
+      target.put(WorldStatType.MOB, worldStat);
+    }
+  }
+
+  private void buildItemStats(Multimap<WorldStatType, WorldStat> target, StatsScreenShadow shadow) {
+    ItemListShadow items = shadow.getItemStats();
+
+    for (Item item : items.getAvailableItems()) {
+      Map<ItemStatType, Integer> values = new HashMap<>();
+      Map<ItemStatType, String> formattedValues = new HashMap<>();
+
+      if (item instanceof BlockItem) {
+        Block block = ((BlockItem) item).getBlock();
+        for (StatType<Block> type : items.getBlockStatTypes()) {
+          this.handleItemStat(values, formattedValues, shadow.getStatsManager(), type, block);
+        }
+      }
+
+      for (StatType<Item> type : items.getItemStatTypes()) {
+        this.handleItemStat(values, formattedValues, shadow.getStatsManager(), type, item);
+      }
+
+      ItemType type = this.itemMapper.fromMinecraftType(item);
+      target.put(WorldStatType.ITEM,
+          this.itemStatFactory.create(this.itemCategory, type, values, formattedValues));
+    }
+  }
+
+  private <T> void handleItemStat(
+      Map<ItemStatType, Integer> target,
+      Map<ItemStatType, String> formattedTarget,
+      StatisticsManager statsManager, StatType<T> type, T item) {
+    Stat<T> stat = type.get(item);
+    int value = statsManager.getValue(stat);
+    if (value <= 0) {
+      return;
+    }
+
+    ItemStatType flintType = ITEM_STAT_TYPES.get(type);
+    if (flintType != null) {
+      target.put(flintType, value);
+      formattedTarget.put(flintType, stat.format(value));
+    }
+  }
+
+  private ChatComponent buildMobComponent(EntityType entityType, String translationKey,
+      boolean valueFirst, int value) {
+    TranslationComponentBuilder builder = this.componentBuilderFactory.newBuilder()
+        .translationKey(translationKey + (value == 0 ? ".none" : ""));
+
+    if (valueFirst && value != 0) {
+      // For the killed value the value is added before the display name
+      builder.appendArgument(String.valueOf(value));
+    }
+    builder.appendArgument(entityType.getDisplayName());
+    if (!valueFirst && value != 0) {
+      // For the killedBy value the value is added after the display name
+      builder.appendArgument(String.valueOf(value));
+    }
+
+    return builder.build();
+  }
+
+  private StatsCategory createCategory(WorldStatType type, String translationKey) {
+    ChatComponent component = this.componentBuilderFactory
+        .newBuilder().translationKey(translationKey).build();
+    return this.categoryFactory.create(type, component);
+  }
+}

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/world/stats/VersionedWorldStatsProvider.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/world/stats/VersionedWorldStatsProvider.java
@@ -1,0 +1,115 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_15_2.world.stats;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.concurrent.CompletableFuture;
+import net.flintmc.framework.eventbus.EventBus;
+import net.flintmc.framework.eventbus.event.subscribe.PostSubscribe;
+import net.flintmc.framework.eventbus.event.subscribe.PreSubscribe;
+import net.flintmc.framework.eventbus.event.subscribe.Subscribe.Phase;
+import net.flintmc.framework.inject.implement.Implement;
+import net.flintmc.mcapi.event.DirectionalEvent.Direction;
+import net.flintmc.mcapi.server.event.PacketEvent;
+import net.flintmc.mcapi.server.event.ServerConnectEvent;
+import net.flintmc.mcapi.server.event.ServerDisconnectEvent;
+import net.flintmc.mcapi.world.stats.WorldStats;
+import net.flintmc.mcapi.world.stats.WorldStatsProvider;
+import net.flintmc.mcapi.world.stats.event.PlayerStatsUpdateEvent;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screen.StatsScreen;
+import net.minecraft.network.play.client.CClientStatusPacket;
+import net.minecraft.network.play.client.CClientStatusPacket.State;
+import net.minecraft.network.play.server.SStatisticsPacket;
+import net.minecraft.stats.StatisticsManager;
+
+@Singleton
+@Implement(value = WorldStatsProvider.class, version = "1.15.2")
+public class VersionedWorldStatsProvider implements WorldStatsProvider {
+
+  private final VersionedWorldStatsMapper mapper;
+  private final StatsScreenShadow screen;
+
+  private final EventBus eventBus;
+  private final PlayerStatsUpdateEvent event;
+
+  private CompletableFuture<WorldStats> pendingRequest;
+
+  @Inject
+  private VersionedWorldStatsProvider(VersionedWorldStatsMapper mapper, EventBus eventBus) {
+    this.mapper = mapper;
+
+    this.eventBus = eventBus;
+    this.event = new PlayerStatsUpdateEvent() {
+    };
+
+    this.screen = (StatsScreenShadow) new StatsScreen(null, new StatisticsManager());
+    this.screen.updateData();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public CompletableFuture<WorldStats> requestStats() {
+    if (this.pendingRequest == null) {
+      if (Minecraft.getInstance().getConnection() == null) {
+        throw new IllegalStateException("Cannot request stats while not connected to a server");
+      }
+
+      this.pendingRequest = new CompletableFuture<>();
+
+      Minecraft.getInstance().getConnection()
+          .sendPacket(new CClientStatusPacket(State.REQUEST_STATS));
+    }
+
+    return this.pendingRequest;
+  }
+
+  @PostSubscribe
+  public void resetPendingRequest(ServerConnectEvent event) {
+    this.pendingRequest = null;
+  }
+
+  @PostSubscribe
+  public void resetPendingRequest(ServerDisconnectEvent event) {
+    this.pendingRequest = null;
+  }
+
+  @PreSubscribe
+  public void processStatsResponse(PacketEvent event) {
+    if (event.getDirection() != Direction.RECEIVE
+        || !(event.getPacket() instanceof SStatisticsPacket)) {
+      return;
+    }
+
+    this.eventBus.fireEvent(this.event, Phase.PRE);
+
+    SStatisticsPacket packet = (SStatisticsPacket) event.getPacket();
+    packet.getStatisticMap()
+        .forEach((stat, value) -> this.screen.getStatsManager().setValue(null, stat, value));
+    this.screen.updateData();
+
+    this.pendingRequest.complete(this.mapper.map(this.screen));
+
+    this.eventBus.fireEvent(this.event, Phase.POST);
+  }
+}

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/world/stats/VersionedWorldStatsProvider.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/world/stats/VersionedWorldStatsProvider.java
@@ -59,12 +59,11 @@ public class VersionedWorldStatsProvider implements WorldStatsProvider {
   private WorldStats lastStats;
 
   @Inject
-  private VersionedWorldStatsProvider(VersionedWorldStatsMapper mapper, EventBus eventBus) {
+  private VersionedWorldStatsProvider(
+      VersionedWorldStatsMapper mapper, EventBus eventBus, PlayerStatsUpdateEvent event) {
     this.mapper = mapper;
-
     this.eventBus = eventBus;
-    this.event = new PlayerStatsUpdateEvent() {
-    };
+    this.event = event;
 
     this.shadow = (StatsScreenShadow) new StatsScreen(null, new StatisticsManager());
     this.shadow.updateData();

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/world/stats/event/DefaultPlayerStatsUpdateEvent.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/world/stats/event/DefaultPlayerStatsUpdateEvent.java
@@ -1,0 +1,28 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_15_2.world.stats.event;
+
+import net.flintmc.framework.inject.implement.Implement;
+import net.flintmc.mcapi.world.stats.event.PlayerStatsUpdateEvent;
+
+@Implement(PlayerStatsUpdateEvent.class)
+public class DefaultPlayerStatsUpdateEvent implements PlayerStatsUpdateEvent {
+
+}

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/entity/type/VersionedEntityType.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/entity/type/VersionedEntityType.java
@@ -22,6 +22,7 @@ package net.flintmc.mcapi.v1_16_5.entity.type;
 import net.flintmc.framework.inject.assisted.Assisted;
 import net.flintmc.framework.inject.assisted.AssistedInject;
 import net.flintmc.framework.inject.implement.Implement;
+import net.flintmc.mcapi.chat.component.ChatComponent;
 import net.flintmc.mcapi.entity.Entity;
 import net.flintmc.mcapi.entity.EntitySize;
 import net.flintmc.mcapi.entity.type.EntityType;
@@ -32,6 +33,7 @@ import net.flintmc.mcapi.entity.type.EntityType;
 @Implement(value = EntityType.class, version = "1.16.5")
 public class VersionedEntityType implements EntityType {
 
+  private final ChatComponent displayName;
   private final Entity.Classification classification;
   private final boolean serializable;
   private final boolean summonable;
@@ -41,18 +43,28 @@ public class VersionedEntityType implements EntityType {
 
   @AssistedInject
   private VersionedEntityType(
+      @Assisted("displayName") ChatComponent displayName,
       @Assisted("classification") Entity.Classification classification,
       @Assisted("serializable") boolean serializable,
       @Assisted("summonable") boolean summonable,
       @Assisted("immuneToFire") boolean immuneToFire,
       @Assisted("canSpawnFarFromPlayer") boolean canSpawnFarFromPlayer,
       @Assisted("entitySize") EntitySize entitySize) {
+    this.displayName = displayName;
     this.classification = classification;
     this.serializable = serializable;
     this.summonable = summonable;
     this.immuneToFire = immuneToFire;
     this.canSpawnFarFromPlayer = canSpawnFarFromPlayer;
     this.entitySize = entitySize;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public ChatComponent getDisplayName() {
+    return this.displayName;
   }
 
   /**

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/entity/type/VersionedEntityTypeBuilder.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/entity/type/VersionedEntityTypeBuilder.java
@@ -22,6 +22,7 @@ package net.flintmc.mcapi.v1_16_5.entity.type;
 import net.flintmc.framework.inject.assisted.Assisted;
 import net.flintmc.framework.inject.assisted.AssistedInject;
 import net.flintmc.framework.inject.implement.Implement;
+import net.flintmc.mcapi.chat.component.ChatComponent;
 import net.flintmc.mcapi.entity.Entity;
 import net.flintmc.mcapi.entity.EntitySize;
 import net.flintmc.mcapi.entity.type.EntityType;
@@ -36,6 +37,7 @@ public class VersionedEntityTypeBuilder implements EntityTypeBuilder {
   private final Entity.Classification classification;
   private final EntitySize.Factory entitySizeFactory;
   private final EntityType.Factory entityTypeFactory;
+  private ChatComponent displayName;
   private boolean serializable;
   private boolean summonable;
   private boolean immuneToFire;
@@ -56,6 +58,12 @@ public class VersionedEntityTypeBuilder implements EntityTypeBuilder {
         classification == Entity.Classification.CREATURE
             || classification == Entity.Classification.MISC;
     this.size = entitySizeFactory.create(0.6F, 1.8F, false);
+  }
+
+  @Override
+  public EntityTypeBuilder displayName(ChatComponent displayName) {
+    this.displayName = displayName;
+    return this;
   }
 
   /**
@@ -109,6 +117,7 @@ public class VersionedEntityTypeBuilder implements EntityTypeBuilder {
   @Override
   public EntityType build(String id) {
     return this.entityTypeFactory.create(
+        this.displayName,
         this.classification,
         this.serializable,
         this.summonable,

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/entity/type/VersionedEntityTypeBuilder.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/entity/type/VersionedEntityTypeBuilder.java
@@ -60,6 +60,9 @@ public class VersionedEntityTypeBuilder implements EntityTypeBuilder {
     this.size = entitySizeFactory.create(0.6F, 1.8F, false);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public EntityTypeBuilder displayName(ChatComponent displayName) {
     this.displayName = displayName;

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/entity/type/VersionedEntityTypeMapper.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/entity/type/VersionedEntityTypeMapper.java
@@ -22,6 +22,8 @@ package net.flintmc.mcapi.v1_16_5.entity.type;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import net.flintmc.framework.inject.implement.Implement;
+import net.flintmc.mcapi.chat.builder.TranslationComponentBuilder;
+import net.flintmc.mcapi.chat.builder.TranslationComponentBuilder.Factory;
 import net.flintmc.mcapi.entity.Entity;
 import net.flintmc.mcapi.entity.Entity.Classification;
 import net.flintmc.mcapi.entity.EntitySize;
@@ -36,12 +38,15 @@ import net.minecraft.entity.EntityClassification;
 @Implement(value = EntityTypeMapper.class, version = "1.16.5")
 public class VersionedEntityTypeMapper implements EntityTypeMapper {
 
+  private final TranslationComponentBuilder.Factory componentFactory;
   private final EntityType.Factory entityTypeFactory;
   private final EntitySize.Factory entitySizeFactory;
 
   @Inject
   private VersionedEntityTypeMapper(
+      Factory componentFactory,
       EntityType.Factory entityTypeFactory, EntitySize.Factory entitySizeFactory) {
+    this.componentFactory = componentFactory;
     this.entityTypeFactory = entityTypeFactory;
     this.entitySizeFactory = entitySizeFactory;
   }
@@ -61,6 +66,7 @@ public class VersionedEntityTypeMapper implements EntityTypeMapper {
     net.minecraft.entity.EntityType type = (net.minecraft.entity.EntityType) handle;
 
     return this.entityTypeFactory.create(
+        this.componentFactory.newBuilder().translationKey(type.getTranslationKey()).build(),
         this.fromMinecraftEntityClassification(type.getClassification()),
         type.isSerializable(),
         type.isSummonable(),

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/items/mapper/VersionedMinecraftItemMapper.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/items/mapper/VersionedMinecraftItemMapper.java
@@ -51,6 +51,9 @@ public class VersionedMinecraftItemMapper implements MinecraftItemMapper {
     this.metaFactory = metaFactory;
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public ItemStack fromMinecraft(Object handle) throws ItemMappingException {
     if (!(handle instanceof net.minecraft.item.ItemStack)) {
@@ -61,14 +64,7 @@ public class VersionedMinecraftItemMapper implements MinecraftItemMapper {
     }
     net.minecraft.item.ItemStack stack = (net.minecraft.item.ItemStack) handle;
 
-    ResourceLocation resourceLocation = Registry.ITEM.getKey(stack.getItem());
-    NameSpacedKey registryName =
-        NameSpacedKey.of(resourceLocation.getNamespace(), resourceLocation.getPath());
-
-    ItemType type = this.registry.getType(registryName);
-    if (type == null) {
-      throw new ItemMappingException("No item type with the name " + registryName + " found");
-    }
+    ItemType type = this.fromMinecraftType(stack.getItem());
 
     ItemMeta meta = this.metaFactory.createMeta(type);
 
@@ -79,15 +75,12 @@ public class VersionedMinecraftItemMapper implements MinecraftItemMapper {
     return this.itemFactory.createItemStack(type, stack.getCount(), meta);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public Object toMinecraft(ItemStack stack) throws ItemMappingException {
-    Item item =
-        Registry.ITEM
-            .getOptional(stack.getType().getResourceLocation().getHandle())
-            .orElseThrow(
-                () ->
-                    new ItemMappingException(
-                        "Unknown item " + stack.getType().getResourceLocation()));
+    Item item = (Item) this.toMinecraftType(stack.getType());
 
     net.minecraft.item.ItemStack result =
         new net.minecraft.item.ItemStack(new IItemProvider() {
@@ -103,5 +96,31 @@ public class VersionedMinecraftItemMapper implements MinecraftItemMapper {
     }
 
     return result;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public ItemType fromMinecraftType(Object handle) {
+    ResourceLocation resourceLocation = Registry.ITEM.getKey((Item) handle);
+    NameSpacedKey registryName =
+        NameSpacedKey.of(resourceLocation.getNamespace(), resourceLocation.getPath());
+
+    ItemType type = this.registry.getType(registryName);
+    if (type == null) {
+      throw new ItemMappingException("No item type with the name " + registryName + " found");
+    }
+
+    return type;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Object toMinecraftType(ItemType type) {
+    return Registry.ITEM.getOptional(type.getResourceLocation().getHandle())
+        .orElseThrow(() -> new ItemMappingException("Unknown item " + type.getResourceLocation()));
   }
 }

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/server/event/PacketEventInjectionTransformer.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/server/event/PacketEventInjectionTransformer.java
@@ -1,0 +1,77 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_16_5.server.event;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.CtField;
+import javassist.CtMethod;
+import javassist.NotFoundException;
+import net.flintmc.framework.inject.InjectedFieldBuilder.Factory;
+import net.flintmc.transform.hook.Hook.ExecutionTime;
+import net.flintmc.transform.javassist.ClassTransform;
+import net.flintmc.transform.javassist.ClassTransformContext;
+import net.flintmc.transform.javassist.CtClassFilter;
+import net.flintmc.transform.javassist.CtClassFilters;
+import net.flintmc.util.mappings.ClassMappingProvider;
+
+@Singleton
+public class PacketEventInjectionTransformer {
+
+  private final ClassMappingProvider mappingProvider;
+  private final Factory fieldBuilderFactory;
+
+  @Inject
+  private PacketEventInjectionTransformer(
+      ClassMappingProvider mappingProvider, Factory fieldBuilderFactory) {
+    this.mappingProvider = mappingProvider;
+    this.fieldBuilderFactory = fieldBuilderFactory;
+  }
+
+  @ClassTransform(version = "1.16.5")
+  @CtClassFilter(value = CtClassFilters.SUBCLASS_OF, className = "net.minecraft.network.IPacket")
+  public void transformPacket(ClassTransformContext context)
+      throws NotFoundException, CannotCompileException {
+    CtClass packet = context.getCtClass();
+
+    CtClass netHandler = packet.getClassPool()
+        .get(this.mappingProvider.get("net.minecraft.network.INetHandler").getName());
+
+    for (CtMethod method : packet.getDeclaredMethods()) {
+      CtClass[] params = method.getParameterTypes();
+      if (params.length != 1 || !params[0].subtypeOf(netHandler)) {
+        continue;
+      }
+
+      CtField injectorField = fieldBuilderFactory.create()
+          .target(packet)
+          .inject(PacketEventInjector.class)
+          .generate();
+
+      method.insertAfter(
+          String.format("{ %s.processIncomingPacket(new Object[]{$0}, %s.AFTER); }",
+              injectorField.getName(),
+              ExecutionTime.class.getName()));
+      break;
+    }
+  }
+}

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/server/event/PacketEventInjector.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/server/event/PacketEventInjector.java
@@ -52,13 +52,12 @@ public class PacketEventInjector {
   }
 
   @Hook(
-      executionTime = {ExecutionTime.BEFORE, ExecutionTime.AFTER},
+      executionTime = ExecutionTime.BEFORE,
       className = "net.minecraft.network.NetworkManager",
       methodName = "processPacket",
       parameters = {@Type(reference = IPacket.class), @Type(reference = INetHandler.class)},
       version = "1.16.5")
-  public HookResult processIncomingPacket(
-      ExecutionTime executionTime, @Named("args") Object[] args) {
+  public HookResult processIncomingPacket(@Named("args") Object[] args, ExecutionTime executionTime) {
     Object packet = args[0];
     ProtocolType type = ProtocolType.getFromPacket((IPacket<?>) packet);
     if (type == null) {

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/server/event/ServerConnectEventInjector.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/server/event/ServerConnectEventInjector.java
@@ -24,6 +24,7 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import net.flintmc.framework.eventbus.EventBus;
 import net.flintmc.framework.eventbus.event.subscribe.PostSubscribe;
+import net.flintmc.framework.eventbus.event.subscribe.PreSubscribe;
 import net.flintmc.framework.eventbus.event.subscribe.Subscribe.Phase;
 import net.flintmc.framework.stereotype.type.Type;
 import net.flintmc.mcapi.event.DirectionalEvent.Direction;
@@ -67,7 +68,7 @@ public class ServerConnectEventInjector {
   }
 
 
-  @PostSubscribe(version = "1.16.5")
+  @PreSubscribe(version = "1.16.5")
   public void handleLoginSuccess(PacketEvent event) {
     if (event.getDirection() != Direction.RECEIVE || event.getPhase() != ProtocolPhase.LOGIN
         || !(event.getPacket() instanceof SLoginSuccessPacket)

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/world/stats/StatsScreenShadow.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/world/stats/StatsScreenShadow.java
@@ -24,7 +24,6 @@ import net.flintmc.transform.shadow.FieldGetter;
 import net.flintmc.transform.shadow.MethodProxy;
 import net.flintmc.transform.shadow.Shadow;
 import net.minecraft.block.Block;
-import net.minecraft.client.gui.widget.list.ExtendedList;
 import net.minecraft.entity.EntityType;
 import net.minecraft.item.Item;
 import net.minecraft.stats.Stat;
@@ -50,12 +49,8 @@ public interface StatsScreenShadow {
   @MethodProxy
   void initLists();
 
-  @MethodProxy
-  void func_213110_a(ExtendedList<?> list);
-
   default void updateData() {
     this.initLists();
-    this.func_213110_a((ExtendedList<?>) this.getGeneralStats());
   }
 
   @Shadow(value = "net.minecraft.client.gui.screen.StatsScreen$CustomStatsList", version = "1.16.5")

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/world/stats/StatsScreenShadow.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/world/stats/StatsScreenShadow.java
@@ -1,0 +1,114 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_16_5.world.stats;
+
+import java.util.List;
+import net.flintmc.transform.shadow.FieldGetter;
+import net.flintmc.transform.shadow.MethodProxy;
+import net.flintmc.transform.shadow.Shadow;
+import net.minecraft.block.Block;
+import net.minecraft.client.gui.widget.list.ExtendedList;
+import net.minecraft.entity.EntityType;
+import net.minecraft.item.Item;
+import net.minecraft.stats.Stat;
+import net.minecraft.stats.StatType;
+import net.minecraft.stats.StatisticsManager;
+import net.minecraft.util.ResourceLocation;
+
+@Shadow(value = "net.minecraft.client.gui.screen.StatsScreen", version = "1.16.5")
+public interface StatsScreenShadow {
+
+  @FieldGetter("stats")
+  StatisticsManager getStatsManager();
+
+  @FieldGetter("generalStats")
+  GeneralListShadow getGeneralStats();
+
+  @FieldGetter("mobStats")
+  MobListShadow getMobStats();
+
+  @FieldGetter("itemStats")
+  ItemListShadow getItemStats();
+
+  @MethodProxy
+  void initLists();
+
+  @MethodProxy
+  void func_213110_a(ExtendedList<?> list);
+
+  default void updateData() {
+    this.initLists();
+    this.func_213110_a((ExtendedList<?>) this.getGeneralStats());
+  }
+
+  @Shadow(value = "net.minecraft.client.gui.screen.StatsScreen$CustomStatsList", version = "1.16.5")
+  interface GeneralListShadow {
+
+    @SuppressWarnings("unchecked")
+    default List<GeneralStat> getStats() {
+      return (List<GeneralStat>) ((AbstractListShadow) this).getChildren();
+    }
+
+    @Shadow(value = "net.minecraft.client.gui.screen.StatsScreen$CustomStatsList$Entry", version = "1.16.5")
+    interface GeneralStat {
+
+      @FieldGetter("field_214405_b")
+      Stat<ResourceLocation> getStat();
+    }
+  }
+
+  @Shadow(value = "net.minecraft.client.gui.screen.StatsScreen$MobStatsList", version = "1.16.5")
+  interface MobListShadow {
+
+    @SuppressWarnings("unchecked")
+    default List<MobStat> getStats() {
+      return (List<MobStat>) ((AbstractListShadow) this).getChildren();
+    }
+
+    @Shadow(value = "net.minecraft.client.gui.screen.StatsScreen$MobStatsList$Entry", version = "1.16.5")
+    interface MobStat {
+
+      @FieldGetter("field_214411_b")
+      EntityType<?> getEntityType();
+    }
+  }
+
+  @Shadow(value = "net.minecraft.client.gui.screen.StatsScreen$StatsList", version = "1.16.5")
+  interface ItemListShadow {
+
+    @FieldGetter("field_195113_v")
+    List<StatType<Block>> getBlockStatTypes();
+
+    @FieldGetter("field_195114_w")
+    List<StatType<Item>> getItemStatTypes();
+
+    @FieldGetter("field_195116_y")
+    List<Item> getAvailableItems();
+  }
+
+  @Shadow(value = "net.minecraft.client.gui.widget.list.AbstractList", version = "1.16.5")
+  interface AbstractListShadow {
+
+    @FieldGetter("children")
+    List<?> getChildren();
+
+  }
+
+}

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/world/stats/VersionedWorldStatsMapper.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/world/stats/VersionedWorldStatsMapper.java
@@ -1,0 +1,223 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_16_5.world.stats;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Multimap;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.HashMap;
+import java.util.Map;
+import net.flintmc.mcapi.chat.builder.TranslationComponentBuilder;
+import net.flintmc.mcapi.chat.component.ChatComponent;
+import net.flintmc.mcapi.entity.type.EntityType;
+import net.flintmc.mcapi.entity.type.EntityTypeMapper;
+import net.flintmc.mcapi.items.mapper.MinecraftItemMapper;
+import net.flintmc.mcapi.items.type.ItemType;
+import net.flintmc.mcapi.v1_16_5.world.stats.StatsScreenShadow.GeneralListShadow.GeneralStat;
+import net.flintmc.mcapi.v1_16_5.world.stats.StatsScreenShadow.ItemListShadow;
+import net.flintmc.mcapi.v1_16_5.world.stats.StatsScreenShadow.MobListShadow.MobStat;
+import net.flintmc.mcapi.world.stats.StatsCategory;
+import net.flintmc.mcapi.world.stats.WorldStatType;
+import net.flintmc.mcapi.world.stats.WorldStats;
+import net.flintmc.mcapi.world.stats.WorldStats.Factory;
+import net.flintmc.mcapi.world.stats.value.GeneralWorldStat;
+import net.flintmc.mcapi.world.stats.value.ItemWorldStat;
+import net.flintmc.mcapi.world.stats.value.ItemWorldStat.ItemStatType;
+import net.flintmc.mcapi.world.stats.value.MobWorldStat;
+import net.flintmc.mcapi.world.stats.value.WorldStat;
+import net.minecraft.block.Block;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.stats.Stat;
+import net.minecraft.stats.StatType;
+import net.minecraft.stats.StatisticsManager;
+import net.minecraft.stats.Stats;
+
+@Singleton
+public class VersionedWorldStatsMapper {
+
+  private static final Map<StatType<?>, ItemStatType> ITEM_STAT_TYPES = new HashMap<>();
+
+  static {
+    ITEM_STAT_TYPES.put(Stats.BLOCK_MINED, ItemStatType.BLOCK_MINED);
+    ITEM_STAT_TYPES.put(Stats.ITEM_BROKEN, ItemStatType.ITEM_BROKEN);
+    ITEM_STAT_TYPES.put(Stats.ITEM_CRAFTED, ItemStatType.ITEM_CRAFTED);
+    ITEM_STAT_TYPES.put(Stats.ITEM_USED, ItemStatType.ITEM_USED);
+    ITEM_STAT_TYPES.put(Stats.ITEM_PICKED_UP, ItemStatType.ITEM_PICKED_UP);
+    ITEM_STAT_TYPES.put(Stats.ITEM_DROPPED, ItemStatType.ITEM_DROPPED);
+  }
+
+  private final Factory statsFactory;
+  private final StatsCategory.Factory categoryFactory;
+  private final GeneralWorldStat.Factory simpleStatFactory;
+  private final MobWorldStat.Factory mobStatFactory;
+  private final ItemWorldStat.Factory itemStatFactory;
+
+  private final TranslationComponentBuilder.Factory componentBuilderFactory;
+  private final EntityTypeMapper entityTypeMapper;
+  private final MinecraftItemMapper itemMapper;
+
+  private final StatsCategory generalCategory;
+  private final StatsCategory mobCategory;
+  private final StatsCategory itemCategory;
+  private final Map<WorldStatType, StatsCategory> categories;
+
+  @Inject
+  private VersionedWorldStatsMapper(
+      Factory statsFactory,
+      StatsCategory.Factory categoryFactory,
+      GeneralWorldStat.Factory simpleStatFactory,
+      MobWorldStat.Factory mobStatFactory,
+      ItemWorldStat.Factory itemStatFactory,
+      TranslationComponentBuilder.Factory componentBuilderFactory,
+      EntityTypeMapper entityTypeMapper,
+      MinecraftItemMapper itemMapper) {
+    this.statsFactory = statsFactory;
+    this.componentBuilderFactory = componentBuilderFactory;
+    this.categoryFactory = categoryFactory;
+    this.simpleStatFactory = simpleStatFactory;
+    this.mobStatFactory = mobStatFactory;
+    this.itemStatFactory = itemStatFactory;
+    this.entityTypeMapper = entityTypeMapper;
+    this.itemMapper = itemMapper;
+
+    this.generalCategory = this.createCategory(WorldStatType.GENERAL, "stat.generalButton");
+    this.itemCategory = this.createCategory(WorldStatType.ITEM, "stat.itemsButton");
+    this.mobCategory = this.createCategory(WorldStatType.MOB, "stat.mobsButton");
+
+    this.categories = ImmutableMap.of(
+        WorldStatType.GENERAL, this.generalCategory,
+        WorldStatType.ITEM, this.itemCategory,
+        WorldStatType.MOB, this.mobCategory
+    );
+  }
+
+  public Map<WorldStatType, StatsCategory> getCategories() {
+    return this.categories;
+  }
+
+  public WorldStats map(StatsScreenShadow shadow) {
+    Multimap<WorldStatType, WorldStat> stats = HashMultimap.create();
+
+    this.buildSimpleStats(stats, shadow);
+    this.buildMobStats(stats, shadow);
+    this.buildItemStats(stats, shadow);
+
+    return this.statsFactory.create(System.currentTimeMillis(), stats);
+  }
+
+  private void buildSimpleStats(
+      Multimap<WorldStatType, WorldStat> target, StatsScreenShadow shadow) {
+    for (GeneralStat stat : shadow.getGeneralStats().getStats()) {
+      int value = shadow.getStatsManager().getValue(stat.getStat());
+      ChatComponent displayName = this.componentBuilderFactory.newBuilder()
+          .translationKey("stat." + stat.getStat().getValue().toString().replace(':', '.'))
+          .build();
+
+      target.put(WorldStatType.GENERAL, this.simpleStatFactory
+          .create(this.generalCategory, displayName, stat.getStat().format(value), value));
+    }
+  }
+
+  private void buildMobStats(Multimap<WorldStatType, WorldStat> target, StatsScreenShadow shadow) {
+    for (MobStat stat : shadow.getMobStats().getStats()) {
+      net.minecraft.entity.EntityType<?> rawEntityType = stat.getEntityType();
+      EntityType entityType = this.entityTypeMapper.fromMinecraftEntityType(rawEntityType);
+
+      int killed = shadow.getStatsManager().getValue(Stats.ENTITY_KILLED.get(rawEntityType));
+      int killedBy = shadow.getStatsManager().getValue(Stats.ENTITY_KILLED_BY.get(rawEntityType));
+      ChatComponent killedComponent = this.buildMobComponent(
+          entityType, Stats.ENTITY_KILLED.getTranslationKey(), true, killed);
+      ChatComponent killedByComponent = this.buildMobComponent(
+          entityType, Stats.ENTITY_KILLED_BY.getTranslationKey(), false, killedBy);
+
+      MobWorldStat worldStat = this.mobStatFactory.create(
+          this.mobCategory, entityType, killedComponent, killedByComponent, killed, killedBy);
+      target.put(WorldStatType.MOB, worldStat);
+    }
+  }
+
+  private void buildItemStats(Multimap<WorldStatType, WorldStat> target, StatsScreenShadow shadow) {
+    ItemListShadow items = shadow.getItemStats();
+
+    for (Item item : items.getAvailableItems()) {
+      Map<ItemStatType, Integer> values = new HashMap<>();
+      Map<ItemStatType, String> formattedValues = new HashMap<>();
+
+      if (item instanceof BlockItem) {
+        Block block = ((BlockItem) item).getBlock();
+        for (StatType<Block> type : items.getBlockStatTypes()) {
+          this.handleItemStat(values, formattedValues, shadow.getStatsManager(), type, block);
+        }
+      }
+
+      for (StatType<Item> type : items.getItemStatTypes()) {
+        this.handleItemStat(values, formattedValues, shadow.getStatsManager(), type, item);
+      }
+
+      ItemType type = this.itemMapper.fromMinecraftType(item);
+      target.put(WorldStatType.ITEM,
+          this.itemStatFactory.create(this.itemCategory, type, values, formattedValues));
+    }
+  }
+
+  private <T> void handleItemStat(
+      Map<ItemStatType, Integer> target,
+      Map<ItemStatType, String> formattedTarget,
+      StatisticsManager statsManager, StatType<T> type, T item) {
+    Stat<T> stat = type.get(item);
+    int value = statsManager.getValue(stat);
+    if (value <= 0) {
+      return;
+    }
+
+    ItemStatType flintType = ITEM_STAT_TYPES.get(type);
+    if (flintType != null) {
+      target.put(flintType, value);
+      formattedTarget.put(flintType, stat.format(value));
+    }
+  }
+
+  private ChatComponent buildMobComponent(EntityType entityType, String translationKey,
+      boolean valueFirst, int value) {
+    TranslationComponentBuilder builder = this.componentBuilderFactory.newBuilder()
+        .translationKey(translationKey + (value == 0 ? ".none" : ""));
+
+    if (valueFirst && value != 0) {
+      // For the killed value the value is added before the display name
+      builder.appendArgument(String.valueOf(value));
+    }
+    builder.appendArgument(entityType.getDisplayName());
+    if (!valueFirst && value != 0) {
+      // For the killedBy value the value is added after the display name
+      builder.appendArgument(String.valueOf(value));
+    }
+
+    return builder.build();
+  }
+
+  private StatsCategory createCategory(WorldStatType type, String translationKey) {
+    ChatComponent component = this.componentBuilderFactory
+        .newBuilder().translationKey(translationKey).build();
+    return this.categoryFactory.create(type, component);
+  }
+}

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/world/stats/VersionedWorldStatsProvider.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/world/stats/VersionedWorldStatsProvider.java
@@ -17,10 +17,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package net.flintmc.mcapi.v1_15_2.world.stats;
+package net.flintmc.mcapi.v1_16_5.world.stats;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import net.flintmc.framework.eventbus.EventBus;
 import net.flintmc.framework.eventbus.event.subscribe.PostSubscribe;
 import net.flintmc.framework.eventbus.event.subscribe.Subscribe;
@@ -42,11 +44,8 @@ import net.minecraft.network.play.client.CClientStatusPacket.State;
 import net.minecraft.network.play.server.SStatisticsPacket;
 import net.minecraft.stats.StatisticsManager;
 
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-
 @Singleton
-@Implement(value = WorldStatsProvider.class, version = "1.15.2")
+@Implement(value = WorldStatsProvider.class, version = "1.16.5")
 public class VersionedWorldStatsProvider implements WorldStatsProvider {
 
   private final VersionedWorldStatsMapper mapper;
@@ -106,12 +105,12 @@ public class VersionedWorldStatsProvider implements WorldStatsProvider {
     return this.mapper.getCategories();
   }
 
-  @PostSubscribe(version = "1.15.2")
+  @PostSubscribe(version = "1.16.5")
   public void resetPendingRequest(ServerConnectEvent event) {
     this.reset();
   }
 
-  @PostSubscribe(version = "1.15.2")
+  @PostSubscribe(version = "1.16.5")
   public void resetPendingRequest(ServerDisconnectEvent event) {
     this.reset();
   }
@@ -121,7 +120,7 @@ public class VersionedWorldStatsProvider implements WorldStatsProvider {
     this.lastStats = null;
   }
 
-  @Subscribe(phase = Phase.ANY, version = "1.15.2")
+  @Subscribe(phase = Phase.ANY, version = "1.16.5")
   public void processStatsResponse(PacketEvent event, Phase phase) {
     if (event.getDirection() != Direction.RECEIVE
         || !(event.getPacket() instanceof SStatisticsPacket)) {

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/world/stats/VersionedWorldStatsProvider.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/world/stats/VersionedWorldStatsProvider.java
@@ -21,8 +21,6 @@ package net.flintmc.mcapi.v1_16_5.world.stats;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import net.flintmc.framework.eventbus.EventBus;
 import net.flintmc.framework.eventbus.event.subscribe.PostSubscribe;
 import net.flintmc.framework.eventbus.event.subscribe.Subscribe;
@@ -44,6 +42,9 @@ import net.minecraft.network.play.client.CClientStatusPacket.State;
 import net.minecraft.network.play.server.SStatisticsPacket;
 import net.minecraft.stats.StatisticsManager;
 
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
 @Singleton
 @Implement(value = WorldStatsProvider.class, version = "1.16.5")
 public class VersionedWorldStatsProvider implements WorldStatsProvider {
@@ -58,12 +59,11 @@ public class VersionedWorldStatsProvider implements WorldStatsProvider {
   private WorldStats lastStats;
 
   @Inject
-  private VersionedWorldStatsProvider(VersionedWorldStatsMapper mapper, EventBus eventBus) {
+  private VersionedWorldStatsProvider(
+      VersionedWorldStatsMapper mapper, EventBus eventBus, PlayerStatsUpdateEvent event) {
     this.mapper = mapper;
-
     this.eventBus = eventBus;
-    this.event = new PlayerStatsUpdateEvent() {
-    };
+    this.event = event;
 
     this.shadow = (StatsScreenShadow) new StatsScreen(null, new StatisticsManager());
     this.shadow.updateData();


### PR DESCRIPTION
Adds a module to the mcapi to get access to the statistics in a world. It also fixes that the PacketEvent is not fired in the POST phase for the receive direction.