### PR TITLE
Fix parsing of legacy text components in 1.16.5

### DIFF
--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/chat/VersionedMinecraftComponentMapper.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/chat/VersionedMinecraftComponentMapper.java
@@ -133,9 +133,7 @@ public class VersionedMinecraftComponentMapper implements MinecraftComponentMapp
 
     } else if (component instanceof StringTextComponent) {
 
-      return this.builderFactory.text()
-          .text(((StringTextComponent) component).getText())
-          .build();
+      return this.parseText(((StringTextComponent) component).getText());
 
     } else if (component instanceof TranslationTextComponent) {
 


### PR DESCRIPTION
Some servers still send chat messages in the legacy format (e.g. "§a" in the text instead of "color: green" in the json) which needs to be parsed properly.