### PR TITLE
Fix wrong priority of ConfigStorageService, add eventClass to EventDetails

### DIFF
--- a/framework/config/src/internal/java/net/flintmc/framework/config/internal/storage/ConfigStorageService.java
+++ b/framework/config/src/internal/java/net/flintmc/framework/config/internal/storage/ConfigStorageService.java
@@ -33,7 +33,7 @@ import net.flintmc.processing.autoload.AnnotationMeta;
 import net.flintmc.processing.autoload.identifier.Identifier;
 
 @Singleton
-@Service(StoragePriority.class)
+@Service(value = StoragePriority.class, priority = -1)
 public class ConfigStorageService implements ServiceHandler<StoragePriority> {
 
   private final ConfigStorageProvider storageProvider;

--- a/framework/config/src/internal/java/net/flintmc/framework/config/internal/storage/DefaultConfigStorageProvider.java
+++ b/framework/config/src/internal/java/net/flintmc/framework/config/internal/storage/DefaultConfigStorageProvider.java
@@ -21,18 +21,7 @@ package net.flintmc.framework.config.internal.storage;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import net.flintmc.framework.config.EventConfigInitializer;
 import net.flintmc.framework.config.event.ConfigStorageEvent;
-import net.flintmc.framework.config.generator.ConfigAnnotationCollector;
-import net.flintmc.framework.config.generator.ConfigGenerator;
 import net.flintmc.framework.config.generator.ParsedConfig;
 import net.flintmc.framework.config.storage.ConfigStorage;
 import net.flintmc.framework.config.storage.ConfigStorageProvider;
@@ -42,6 +31,14 @@ import net.flintmc.framework.eventbus.event.subscribe.Subscribe;
 import net.flintmc.framework.inject.implement.Implement;
 import net.flintmc.framework.inject.logging.InjectLogger;
 import org.apache.logging.log4j.Logger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 @Singleton
 @Implement(ConfigStorageProvider.class)
@@ -52,30 +49,19 @@ public class DefaultConfigStorageProvider implements ConfigStorageProvider {
   private final Logger logger;
   private final EventBus eventBus;
   private final ConfigStorageEvent.Factory eventFactory;
-  private final ConfigAnnotationCollector annotationCollector;
-
-  private final ConfigGenerator configGenerator;
 
   private final List<ComparableConfigStorage> storages = new ArrayList<>();
   private final Map<Class<?>, ParsedConfig> pendingWrites = new ConcurrentHashMap<>();
-
-  private final EventConfigInitializer eventConfigInitializer;
 
   @Inject
   private DefaultConfigStorageProvider(
       @InjectLogger Logger logger,
       ConfigStorageEvent.Factory eventFactory,
       EventBus eventBus,
-      ScheduledExecutorService executorService,
-      ConfigAnnotationCollector annotationCollector,
-      ConfigGenerator configGenerator,
-      EventConfigInitializer eventConfigInitializer) {
+      ScheduledExecutorService executorService) {
     this.logger = logger;
     this.eventFactory = eventFactory;
     this.eventBus = eventBus;
-    this.annotationCollector = annotationCollector;
-    this.configGenerator = configGenerator;
-    this.eventConfigInitializer = eventConfigInitializer;
     executorService.scheduleAtFixedRate(
         () -> {
           if (this.pendingWrites.isEmpty()) {

--- a/framework/eventbus/src/internal/java/net/flintmc/framework/eventbus/internal/method/subscribable/EventTransform.java
+++ b/framework/eventbus/src/internal/java/net/flintmc/framework/eventbus/internal/method/subscribable/EventTransform.java
@@ -23,15 +23,24 @@ import javassist.CtField;
 
 class EventTransform {
 
+  private final String eventClass;
   private final CtField methodsField;
   private final CtField unmodifiableMethodsField;
   private final CtField phasesField;
 
-  public EventTransform(CtField methodsField, CtField unmodifiableMethodsField,
+  public EventTransform(
+      String eventClass,
+      CtField methodsField,
+      CtField unmodifiableMethodsField,
       CtField phasesField) {
+    this.eventClass = eventClass;
     this.methodsField = methodsField;
     this.unmodifiableMethodsField = unmodifiableMethodsField;
     this.phasesField = phasesField;
+  }
+
+  public String getEventClass() {
+    return this.eventClass;
   }
 
   public CtField getMethodsField() {

--- a/framework/eventbus/src/internal/java/net/flintmc/framework/eventbus/internal/method/subscribable/SubscribableService.java
+++ b/framework/eventbus/src/internal/java/net/flintmc/framework/eventbus/internal/method/subscribable/SubscribableService.java
@@ -258,7 +258,7 @@ public class SubscribableService implements LateInjectedTransformer, ServiceHand
 
     generating.addField(phasesField);
 
-    return new EventTransform(methodsField, unmodifiableMethodsField, phasesField);
+    return new EventTransform(eventClass, methodsField, unmodifiableMethodsField, phasesField);
   }
 
   private boolean shouldTransformEventClass(String name) {
@@ -282,6 +282,11 @@ public class SubscribableService implements LateInjectedTransformer, ServiceHand
         this.makeGetter("getMethods", transforming, transform.getUnmodifiableMethodsField()));
     transforming.addMethod(
         this.makeGetter("getSupportedPhases", transforming, transform.getPhasesField()));
+
+    CtMethod eventClassGetter =
+        new CtMethod(this.pool.get("java.lang.Class"), "getEventClass", null, transforming);
+    eventClassGetter.setBody(String.format("return %s.class;", transform.getEventClass()));
+    transforming.addMethod(eventClassGetter);
   }
 
   private CtMethod makeGetter(String name, CtClass declaring, CtField target)

--- a/framework/eventbus/src/main/java/net/flintmc/framework/eventbus/event/EventDetails.java
+++ b/framework/eventbus/src/main/java/net/flintmc/framework/eventbus/event/EventDetails.java
@@ -53,4 +53,13 @@ public interface EventDetails {
    */
   Collection<Phase> getSupportedPhases();
 
+  /**
+   * Retrieves the class/interface that is annotated with {@link Subscribable}, this may not be the
+   * same as the class of this instance. For example if the annotation is present on an interface
+   * and its implementation is the actual event being fired.
+   *
+   * @return The non-null class
+   */
+  Class<? extends Event> getEventClass();
+
 }


### PR DESCRIPTION
This PR fixes that the priority of the ConfigStorageService is the same as the one of the ConfigGenerationService and therefore might be discovered in the wrong order.
It also adds a method to the EventDetails interface to get the original class of an Event and a method to the EventBus to fire an event in the PRE and POST phases more easily.