### PR TITLE
Fix missing publishing by re-activating gradle plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ src/test/
 versioned/*/Labyfy
 .idea/intellij-javadocs-4.0.1.xml
 **/.flint
+docs/generated/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,8 +79,6 @@ flint {
     projectFilter {
         !arrayOf(
                 ":",
-                ":annotation-processing",
-                ":annotation-processing:annotation-processing-autoload",
                 ":framework",
                 ":render",
                 ":transform",


### PR DESCRIPTION
Fix the missing publish tasks in the annotation processor