### PR TITLE
Update DetectableAnnotationProcessor.java

### DIFF
--- a/annotation-processing/autoload/src/main/java/net/flintmc/processing/autoload/DetectableAnnotationProcessor.java
+++ b/annotation-processing/autoload/src/main/java/net/flintmc/processing/autoload/DetectableAnnotationProcessor.java
@@ -235,7 +235,8 @@ public class DetectableAnnotationProcessor implements Processor {
                     SimpleAnnotationMirror.of(
                         repeatedAnnotationType,
                         AnnotationMirrorUtil.getElementValuesByName(
-                            ((AnnotationMirror) repeatedAnnotation)))
+                          repeatedAnnotation instanceof AnnotationMirror ?
+                            (AnnotationMirror)repeatedAnnotation : (AnnotationMirror) repeatedAnnotation.getValue()))
                         .getElementValues());
         if (parsedAnnotation.isEmpty()) {
           return;


### PR DESCRIPTION
Closes #171 

If used in compilation with the eclipse compiler, ClassCastExceptions will occur. This PR fixes it.