### PR TITLE
Add basic debug keybindings support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ hs_err_pid*
 .idea/**/.name
 .idea/**/vcs.xml
 .idea/**/compiler.xml
+.idea/**/libraries-with-intellij-classes.xml
 run/**
 
 # Sensitive or high-churn files

--- a/mcapi/src/internal/java/net/flintmc/mcapi/internal/debug/DefaultMinecraftDebugger.java
+++ b/mcapi/src/internal/java/net/flintmc/mcapi/internal/debug/DefaultMinecraftDebugger.java
@@ -1,0 +1,110 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.internal.debug;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BooleanSupplier;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import net.flintmc.framework.inject.implement.Implement;
+import net.flintmc.mcapi.chat.builder.TextComponentBuilder;
+import net.flintmc.mcapi.chat.builder.TranslationComponentBuilder;
+import net.flintmc.mcapi.chat.component.ChatComponent;
+import net.flintmc.mcapi.debug.MinecraftDebugger;
+import net.flintmc.mcapi.player.ClientPlayer;
+import net.flintmc.render.gui.input.Key;
+import net.flintmc.util.commons.Pair;
+
+@Implement(MinecraftDebugger.class)
+@Singleton
+public class DefaultMinecraftDebugger implements MinecraftDebugger {
+
+  private final Map<Key, Pair<ChatComponent, BooleanSupplier>> registeredKeyBindings;
+  private final Map<Key, ChatComponent> minecraftProvided;
+  private final Multimap<Key, Runnable> hooks;
+
+  private final TextComponentBuilder.Factory textComponentBuilderFactory;
+  private final TranslationComponentBuilder.Factory translationComponentBuilderFactory;
+  private final ClientPlayer player;
+
+  @Inject
+  private DefaultMinecraftDebugger(
+      TextComponentBuilder.Factory textComponentBuilderFactory,
+      TranslationComponentBuilder.Factory translationComponentBuilderFactory,
+      ClientPlayer player
+  ) {
+    this.textComponentBuilderFactory = textComponentBuilderFactory;
+    this.translationComponentBuilderFactory = translationComponentBuilderFactory;
+    this.player = player;
+
+    this.registeredKeyBindings = new HashMap<>();
+    this.minecraftProvided = new HashMap<>();
+    this.hooks = HashMultimap.create();
+  }
+
+  @Override
+  public void registerExecutionHook(Key key, Runnable callback) {
+    hooks.put(key, callback);
+  }
+
+  @Override
+  public void registerDebugKeybinding(Key key, ChatComponent description,
+      BooleanSupplier runnable) {
+    registeredKeyBindings.put(key, new Pair<>(description, runnable));
+  }
+
+  // Internal API for now
+  public void registerInternalDebugKeybindings(Map<Key, String> keybindings) {
+    keybindings.forEach((key, translation) -> minecraftProvided.put(key,
+        translationComponentBuilderFactory.newBuilder().translationKey(translation).build()));
+  }
+
+  public boolean handleDebugKey(Key key) {
+    if (minecraftProvided.containsKey(key) || registeredKeyBindings.containsKey(key)) {
+      hooks.get(key).forEach(Runnable::run);
+    }
+
+    Pair<ChatComponent, BooleanSupplier> binding = registeredKeyBindings.get(key);
+
+    if (binding == null) {
+      return false;
+    }
+
+    return binding.second().getAsBoolean();
+  }
+
+  public boolean displayHelp() {
+    // TODO: Translate
+    player.sendMessage(
+        textComponentBuilderFactory.newBuilder().text("Minecraft provided debug keybindings:")
+            .build(), null);
+    minecraftProvided.forEach((key, component) -> player.sendMessage(component, null));
+
+    // TODO: Translate
+    player.sendMessage(
+        textComponentBuilderFactory.newBuilder().text("Flint provided debug keybindings:").build(),
+        null);
+    registeredKeyBindings.forEach((key, data) -> player.sendMessage(data.first(), null));
+    return true;
+  }
+}

--- a/mcapi/src/internal/java/net/flintmc/mcapi/internal/debug/DefaultMinecraftDebugger.java
+++ b/mcapi/src/internal/java/net/flintmc/mcapi/internal/debug/DefaultMinecraftDebugger.java
@@ -73,21 +73,21 @@ public class DefaultMinecraftDebugger implements MinecraftDebugger {
   @Override
   public void registerDebugKeybinding(Key key, ChatComponent description,
       BooleanSupplier runnable) {
-    registeredKeyBindings.put(key, new Pair<>(description, runnable));
+    this.registeredKeyBindings.put(key, new Pair<>(description, runnable));
   }
 
   // Internal API for now
   public void registerInternalDebugKeybindings(Map<Key, String> keybindings) {
-    keybindings.forEach((key, translation) -> minecraftProvided.put(key,
-        translationComponentBuilderFactory.newBuilder().translationKey(translation).build()));
+    keybindings.forEach((key, translation) -> this.minecraftProvided.put(key,
+        this.translationComponentBuilderFactory.newBuilder().translationKey(translation).build()));
   }
 
   public boolean handleDebugKey(Key key) {
-    if (minecraftProvided.containsKey(key) || registeredKeyBindings.containsKey(key)) {
-      eventBus.fireEvent(new DefaultDebugKeyHookEvent(key), Phase.PRE);
+    if (this.minecraftProvided.containsKey(key) || this.registeredKeyBindings.containsKey(key)) {
+      this.eventBus.fireEvent(new DefaultDebugKeyHookEvent(key), Phase.PRE);
     }
 
-    Pair<ChatComponent, BooleanSupplier> binding = registeredKeyBindings.get(key);
+    Pair<ChatComponent, BooleanSupplier> binding = this.registeredKeyBindings.get(key);
 
     if (binding == null) {
       return false;
@@ -99,16 +99,16 @@ public class DefaultMinecraftDebugger implements MinecraftDebugger {
   // Internal API for now
   public boolean displayHelp() {
     // TODO: Translate
-    player.sendMessage(
+    this.player.sendMessage(
         textComponentBuilderFactory.newBuilder().text("Minecraft provided debug keybindings:")
             .build(), null);
-    minecraftProvided.forEach((key, component) -> player.sendMessage(component, null));
+    this.minecraftProvided.forEach((key, component) -> player.sendMessage(component, null));
 
     // TODO: Translate
-    player.sendMessage(
+    this.player.sendMessage(
         textComponentBuilderFactory.newBuilder().text("Flint provided debug keybindings:").build(),
         null);
-    registeredKeyBindings.forEach((key, data) -> player.sendMessage(data.first(), null));
+    this.registeredKeyBindings.forEach((key, data) -> player.sendMessage(data.first(), null));
     return true;
   }
 }

--- a/mcapi/src/internal/java/net/flintmc/mcapi/internal/event/DefaultDebugKeyHookEvent.java
+++ b/mcapi/src/internal/java/net/flintmc/mcapi/internal/event/DefaultDebugKeyHookEvent.java
@@ -17,24 +17,27 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package net.flintmc.mcapi.debug;
+package net.flintmc.mcapi.internal.event;
 
-import java.util.function.BooleanSupplier;
-import net.flintmc.mcapi.chat.component.ChatComponent;
+import net.flintmc.mcapi.event.DebugKeyHookEvent;
 import net.flintmc.render.gui.input.Key;
 
 /**
- * Helper class for various minecraft debugging utilities.
+ * {@inheritDoc}
  */
-public interface MinecraftDebugger {
+public class DefaultDebugKeyHookEvent implements DebugKeyHookEvent {
+
+  private final Key key;
+
+  public DefaultDebugKeyHookEvent(Key key) {
+    this.key = key;
+  }
+
   /**
-   * Registers a new debug keybinding which can then be used in combination with F3.
-   *
-   * @param key         The key which is used in combination with F3
-   * @param description The description to display in the chat
-   * @param callback    The callback to execute when the keybinding is triggered, returns {@code
-   *                    true} to signal that the key has been handled, or {@code false}, to signal
-   *                    that the key has not been handled
+   * {@inheritDoc}
    */
-  void registerDebugKeybinding(Key key, ChatComponent description, BooleanSupplier callback);
+  @Override
+  public Key getKey() {
+    return key;
+  }
 }

--- a/mcapi/src/main/java/net/flintmc/mcapi/debug/MinecraftDebugger.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/debug/MinecraftDebugger.java
@@ -1,0 +1,54 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.debug;
+
+import java.util.function.BooleanSupplier;
+import net.flintmc.mcapi.chat.component.ChatComponent;
+import net.flintmc.render.gui.input.Key;
+
+/**
+ * Helper class for various minecraft debugging utilities.
+ */
+public interface MinecraftDebugger {
+
+  /**
+   * Registers a new hook which is executed before action associated with the debug key. This is
+   * meant to extend already present debug keybindings. The key chosen here must be an already
+   * registered keybinding.
+   * <p>
+   * See {@link #registerDebugKeybinding(Key, ChatComponent, BooleanSupplier)} for a way of
+   * registering or overwriting keybindings.
+   *
+   * @param key      The key to register the hook for
+   * @param callback The callback to execute as the hook
+   */
+  void registerExecutionHook(Key key, Runnable callback);
+
+  /**
+   * Registers a new debug keybinding which can then be used in combination with F3.
+   *
+   * @param key         The key which is used in combination with F3
+   * @param description The description to display in the chat
+   * @param callback    The callback to execute when the keybinding is triggered, returns {@code
+   *                    true} to signal that the key has been handled, or {@code false}, to signal
+   *                    that the key has not been handled
+   */
+  void registerDebugKeybinding(Key key, ChatComponent description, BooleanSupplier callback);
+}

--- a/mcapi/src/main/java/net/flintmc/mcapi/event/DebugKeyHookEvent.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/event/DebugKeyHookEvent.java
@@ -17,24 +17,31 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package net.flintmc.mcapi.debug;
+package net.flintmc.mcapi.event;
 
-import java.util.function.BooleanSupplier;
+import net.flintmc.framework.eventbus.event.Event;
+import net.flintmc.framework.eventbus.event.subscribe.Subscribable;
+import net.flintmc.framework.eventbus.event.subscribe.Subscribe.Phase;
 import net.flintmc.mcapi.chat.component.ChatComponent;
 import net.flintmc.render.gui.input.Key;
+import java.util.function.BooleanSupplier;
 
 /**
- * Helper class for various minecraft debugging utilities.
+ * This event allows adding additional actions to debug keys. It is intentionally not cancellable,
+ * nor is it fired on the post phase. If you want to register a completely new action, use {@link
+ * net.flintmc.mcapi.debug.MinecraftDebugger#registerDebugKeybinding(Key, ChatComponent,
+ * BooleanSupplier)} instead of this event.
+ * <p>
+ * <b>This event will only be fired for existing debug keybindings (Flint or Minecraft
+ * provided)</b>.
  */
-public interface MinecraftDebugger {
+@Subscribable(Phase.PRE)
+public interface DebugKeyHookEvent extends Event {
+
   /**
-   * Registers a new debug keybinding which can then be used in combination with F3.
+   * Retrieves the key which triggered the event.
    *
-   * @param key         The key which is used in combination with F3
-   * @param description The description to display in the chat
-   * @param callback    The callback to execute when the keybinding is triggered, returns {@code
-   *                    true} to signal that the key has been handled, or {@code false}, to signal
-   *                    that the key has not been handled
+   * @return The key which triggered the event
    */
-  void registerDebugKeybinding(Key key, ChatComponent description, BooleanSupplier callback);
+  Key getKey();
 }

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/debug/MinecraftDebuggerHooks.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/debug/MinecraftDebuggerHooks.java
@@ -1,0 +1,84 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_15_2.debug;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import net.flintmc.framework.stereotype.type.Type;
+import net.flintmc.mcapi.chat.builder.TranslationComponentBuilder;
+import net.flintmc.mcapi.internal.debug.DefaultMinecraftDebugger;
+import net.flintmc.render.gui.input.Key;
+import net.flintmc.transform.hook.Hook;
+import net.flintmc.transform.hook.Hook.ExecutionTime;
+import net.flintmc.transform.hook.HookResult;
+
+@Singleton
+public class MinecraftDebuggerHooks {
+
+  private final DefaultMinecraftDebugger debugger;
+
+  @Inject
+  private MinecraftDebuggerHooks(DefaultMinecraftDebugger debugger,
+      TranslationComponentBuilder.Factory translationChatComponentBuilderFactory) {
+    this.debugger = debugger;
+
+    Map<Key, String> internalKeybindings = new HashMap<>();
+    internalKeybindings.put(Key.A, "debug.reload_chunks.help");
+    internalKeybindings.put(Key.B, "debug.show_hitboxes.help");
+    internalKeybindings.put(Key.C, "debug.copy_location.help");
+    internalKeybindings.put(Key.D, "debug.clear_chat.help");
+    internalKeybindings.put(Key.F, "debug.cycle_renderdistance.help");
+    internalKeybindings.put(Key.G, "debug.chunk_boundaries.help");
+    internalKeybindings.put(Key.H, "debug.advanced_tooltips.help");
+    internalKeybindings.put(Key.I, "debug.inspect.help");
+    internalKeybindings.put(Key.N, "debug.creative_spectator.help");
+    internalKeybindings.put(Key.P, "debug.pause_focus.help");
+    internalKeybindings.put(Key.T, "debug.reload_resourcepacks.help");
+
+    this.debugger.registerInternalDebugKeybindings(
+        internalKeybindings
+    );
+
+    this.debugger.registerDebugKeybinding(Key.Q,
+        translationChatComponentBuilderFactory.newBuilder().translationKey("debug.help.help")
+            .build(),
+        debugger::displayHelp);
+  }
+
+  @Hook(
+      className = "net.minecraft.client.KeyboardListener",
+      methodName = "processKeyF3",
+      defaultValue = "true",
+      executionTime = ExecutionTime.BEFORE,
+      parameters = {
+          @Type(reference = int.class)
+      }
+  )
+  public HookResult hookDebugKeyHandler(@Named("args") Object[] args) {
+    if (debugger.handleDebugKey(Key.getByKeyCode((int) args[0]))) {
+      return HookResult.BREAK;
+    }
+
+    return HookResult.CONTINUE;
+  }
+}

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/debug/MinecraftDebuggerHooks.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/debug/MinecraftDebuggerHooks.java
@@ -75,7 +75,7 @@ public class MinecraftDebuggerHooks {
       }
   )
   public HookResult hookDebugKeyHandler(@Named("args") Object[] args) {
-    if (debugger.handleDebugKey(Key.getByKeyCode((int) args[0]))) {
+    if (this.debugger.handleDebugKey(Key.getByKeyCode((int) args[0]))) {
       return HookResult.BREAK;
     }
 

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/debug/MinecraftDebuggerHooks.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/debug/MinecraftDebuggerHooks.java
@@ -1,0 +1,85 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_16_5.debug;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import net.flintmc.framework.stereotype.type.Type;
+import net.flintmc.mcapi.chat.builder.TranslationComponentBuilder;
+import net.flintmc.mcapi.internal.debug.DefaultMinecraftDebugger;
+import net.flintmc.render.gui.input.Key;
+import net.flintmc.transform.hook.Hook;
+import net.flintmc.transform.hook.Hook.ExecutionTime;
+import net.flintmc.transform.hook.HookResult;
+
+@Singleton
+public class MinecraftDebuggerHooks {
+
+  private final DefaultMinecraftDebugger debugger;
+
+  @Inject
+  private MinecraftDebuggerHooks(DefaultMinecraftDebugger debugger,
+      TranslationComponentBuilder.Factory translationChatComponentBuilderFactory) {
+    this.debugger = debugger;
+
+    Map<Key, String> internalKeybindings = new HashMap<>();
+    internalKeybindings.put(Key.A, "debug.reload_chunks.help");
+    internalKeybindings.put(Key.B, "debug.show_hitboxes.help");
+    internalKeybindings.put(Key.C, "debug.copy_location.help");
+    internalKeybindings.put(Key.D, "debug.clear_chat.help");
+    internalKeybindings.put(Key.F, "debug.cycle_renderdistance.help");
+    internalKeybindings.put(Key.G, "debug.chunk_boundaries.help");
+    internalKeybindings.put(Key.H, "debug.advanced_tooltips.help");
+    internalKeybindings.put(Key.I, "debug.inspect.help");
+    internalKeybindings.put(Key.N, "debug.creative_spectator.help");
+    internalKeybindings.put(Key.P, "debug.pause_focus.help");
+    internalKeybindings.put(Key.T, "debug.reload_resourcepacks.help");
+    internalKeybindings.put(Key.F4, "debug.gamemodes.help");
+
+    this.debugger.registerInternalDebugKeybindings(
+        internalKeybindings
+    );
+
+    this.debugger.registerDebugKeybinding(Key.Q,
+        translationChatComponentBuilderFactory.newBuilder().translationKey("debug.help.help")
+            .build(),
+        debugger::displayHelp);
+  }
+
+  @Hook(
+      className = "net.minecraft.client.KeyboardListener",
+      methodName = "processKeyF3",
+      defaultValue = "true",
+      executionTime = ExecutionTime.BEFORE,
+      parameters = {
+          @Type(reference = int.class)
+      }
+  )
+  public HookResult hookDebugKeyHandler(@Named("args") Object[] args) {
+    if (debugger.handleDebugKey(Key.getByKeyCode((int) args[0]))) {
+      return HookResult.BREAK;
+    }
+
+    return HookResult.CONTINUE;
+  }
+}

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/debug/MinecraftDebuggerHooks.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/debug/MinecraftDebuggerHooks.java
@@ -76,7 +76,7 @@ public class MinecraftDebuggerHooks {
       }
   )
   public HookResult hookDebugKeyHandler(@Named("args") Object[] args) {
-    if (debugger.handleDebugKey(Key.getByKeyCode((int) args[0]))) {
+    if (this.debugger.handleDebugKey(Key.getByKeyCode((int) args[0]))) {
       return HookResult.BREAK;
     }
 


### PR DESCRIPTION
This PR adds support for registering and hooking debug keybindings (F3 + something).

A callback powered approach has been chosen to be able to keep track of registered bindings. If wanted, this can later be extended using annotations, but for now this is good enough.

Closes #181 