### PR TITLE
Implement execution of chat ClickEvents

### DIFF
--- a/mcapi/src/internal/java/net/flintmc/mcapi/internal/chat/component/DefaultChatComponent.java
+++ b/mcapi/src/internal/java/net/flintmc/mcapi/internal/chat/component/DefaultChatComponent.java
@@ -135,7 +135,21 @@ public abstract class DefaultChatComponent implements ChatComponent {
    */
   @Override
   public void insertion(String insertion) {
-    this.insertion = insertion;
+    String target = insertion;
+
+    if (insertion != null) {
+      StringBuilder builder = new StringBuilder(insertion.length());
+
+      for (char c : insertion.toCharArray()) {
+        if (c == 167 || c < ' ' || c == 127) {
+          builder.append(c);
+        }
+      }
+
+      target = builder.toString();
+    }
+
+    this.insertion = target;
   }
 
   /**

--- a/mcapi/src/internal/java/net/flintmc/mcapi/internal/chat/component/event/DefaultClickActionExecutorService.java
+++ b/mcapi/src/internal/java/net/flintmc/mcapi/internal/chat/component/event/DefaultClickActionExecutorService.java
@@ -1,0 +1,93 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.internal.chat.component.event;
+
+import com.google.inject.Singleton;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import net.flintmc.framework.inject.implement.Implement;
+import net.flintmc.framework.inject.primitive.InjectionHolder;
+import net.flintmc.framework.stereotype.service.CtResolver;
+import net.flintmc.framework.stereotype.service.Service;
+import net.flintmc.framework.stereotype.service.ServiceHandler;
+import net.flintmc.mcapi.chat.component.event.ClickActionExecutor;
+import net.flintmc.mcapi.chat.component.event.ClickEvent;
+import net.flintmc.mcapi.chat.component.event.ClickEvent.Action;
+import net.flintmc.mcapi.chat.component.event.ClickEventAction;
+import net.flintmc.metaprogramming.AnnotationMeta;
+
+@Singleton
+@Service(ClickEventAction.class)
+@Implement(ClickActionExecutor.class)
+public class DefaultClickActionExecutorService
+    implements ClickActionExecutor, ServiceHandler<ClickEventAction> {
+
+  private final Map<Action, List<ExecutorContainer>> executors = new HashMap<>();
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void discover(AnnotationMeta<ClickEventAction> meta) {
+    ClickEventAction annotation = meta.getAnnotation();
+    ClickActionExecutor executor = InjectionHolder
+        .getInjectedInstance(CtResolver.get(meta.getClassIdentifier().getLocation()));
+
+    List<ExecutorContainer> containers = this.executors
+        .computeIfAbsent(annotation.value(), action -> new ArrayList<>());
+
+    containers.add(new ExecutorContainer(executor, annotation));
+    Collections.sort(containers);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void executeEvent(ClickEvent event) {
+    List<ExecutorContainer> containers =
+        this.executors.getOrDefault(event.getAction(), Collections.emptyList());
+
+    for (ExecutorContainer container : containers) {
+      container.executor.executeEvent(event);
+    }
+  }
+
+  private class ExecutorContainer implements Comparable<ExecutorContainer> {
+
+    private final ClickActionExecutor executor;
+    private final ClickEventAction annotation;
+
+    private ExecutorContainer(ClickActionExecutor executor,
+        ClickEventAction annotation) {
+      this.executor = executor;
+      this.annotation = annotation;
+    }
+
+    @Override
+    public int compareTo(ExecutorContainer o) {
+      // Reversed
+      return Integer.compare(o.annotation.priority(), this.annotation.priority());
+    }
+  }
+}

--- a/mcapi/src/internal/java/net/flintmc/mcapi/internal/chat/component/event/DefaultClickEvent.java
+++ b/mcapi/src/internal/java/net/flintmc/mcapi/internal/chat/component/event/DefaultClickEvent.java
@@ -1,0 +1,74 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.internal.chat.component.event;
+
+import net.flintmc.framework.inject.assisted.Assisted;
+import net.flintmc.framework.inject.assisted.AssistedFactory;
+import net.flintmc.framework.inject.assisted.AssistedInject;
+import net.flintmc.framework.inject.implement.Implement;
+import net.flintmc.mcapi.chat.component.event.ClickActionExecutor;
+import net.flintmc.mcapi.chat.component.event.ClickEvent;
+
+@Implement(ClickEvent.class)
+public class DefaultClickEvent implements ClickEvent {
+
+  private final ClickActionExecutor actionExecutor;
+
+  private final Action action;
+  private final String value;
+
+  @AssistedInject
+  private DefaultClickEvent(
+      ClickActionExecutor actionExecutor, @Assisted Action action, @Assisted String value) {
+    this.actionExecutor = actionExecutor;
+    this.action = action;
+    this.value = value;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Action getAction() {
+    return this.action;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getValue() {
+    return this.value;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void execute() {
+    this.actionExecutor.executeEvent(this);
+  }
+
+  @AssistedFactory(DefaultClickEvent.class)
+  interface InternalFactory {
+
+    DefaultClickEvent create(@Assisted Action action, @Assisted String value);
+  }
+}

--- a/mcapi/src/internal/java/net/flintmc/mcapi/internal/chat/component/event/DefaultClickEventFactory.java
+++ b/mcapi/src/internal/java/net/flintmc/mcapi/internal/chat/component/event/DefaultClickEventFactory.java
@@ -1,0 +1,95 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.internal.chat.component.event;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import net.flintmc.framework.inject.implement.Implement;
+import net.flintmc.mcapi.chat.component.event.ClickEvent;
+import net.flintmc.mcapi.chat.component.event.ClickEvent.Action;
+import net.flintmc.mcapi.internal.chat.component.event.DefaultClickEvent.InternalFactory;
+
+@Singleton
+@Implement(ClickEvent.Factory.class)
+public class DefaultClickEventFactory implements ClickEvent.Factory {
+
+  private final DefaultClickEvent.InternalFactory factory;
+
+  @Inject
+  private DefaultClickEventFactory(InternalFactory factory) {
+    this.factory = factory;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public ClickEvent create(Action action, String value) {
+    return this.factory.create(action, value);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public ClickEvent openUrl(String url) {
+    return this.create(Action.OPEN_URL, url);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public ClickEvent openFile(String path) {
+    return this.create(Action.OPEN_FILE, path);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public ClickEvent runCommand(String command) {
+    return this.create(Action.RUN_COMMAND, command);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public ClickEvent suggestCommand(String command) {
+    return this.create(Action.SUGGEST_COMMAND, command);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public ClickEvent copyToClipboard(String content) {
+    return this.create(Action.COPY_TO_CLIPBOARD, content);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public ClickEvent changeBookPage(int page) {
+    return this.create(Action.CHANGE_PAGE, String.valueOf(page));
+  }
+}

--- a/mcapi/src/internal/java/net/flintmc/mcapi/internal/chat/serializer/gson/GsonChatComponentSerializer.java
+++ b/mcapi/src/internal/java/net/flintmc/mcapi/internal/chat/serializer/gson/GsonChatComponentSerializer.java
@@ -56,6 +56,7 @@ public class GsonChatComponentSerializer
   private final KeybindComponent.Factory keybindFactory;
   private final ScoreComponent.Factory scoreFactory;
   private final SelectorComponentBuilder.Factory selectorFactory;
+  private final ClickEvent.Factory clickEventFactory;
 
   @Inject
   private GsonChatComponentSerializer(
@@ -64,13 +65,15 @@ public class GsonChatComponentSerializer
       TranslationComponent.Factory translationFactory,
       KeybindComponent.Factory keybindFactory,
       ScoreComponent.Factory scoreFactory,
-      SelectorComponentBuilder.Factory selectorFactory) {
+      SelectorComponentBuilder.Factory selectorFactory,
+      ClickEvent.Factory clickEventFactory) {
     this.logger = logger;
     this.textFactory = textFactory;
     this.translationFactory = translationFactory;
     this.keybindFactory = keybindFactory;
     this.scoreFactory = scoreFactory;
     this.selectorFactory = selectorFactory;
+    this.clickEventFactory = clickEventFactory;
   }
 
   // read everything that is the same in any type of component
@@ -109,7 +112,7 @@ public class GsonChatComponentSerializer
       }
 
       if (action != null) {
-        component.clickEvent(ClickEvent.of(action, event.get("value").getAsString()));
+        component.clickEvent(this.clickEventFactory.create(action, event.get("value").getAsString()));
       }
     }
 

--- a/mcapi/src/main/java/net/flintmc/mcapi/chat/ChatController.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/chat/ChatController.java
@@ -46,7 +46,9 @@ public interface ChatController {
 
   /**
    * Sets the current value of the text field in the chat and fires the {@link
-   * ChatInputChangeEvent}, if the chat is currently not opened, only this event will be fired.
+   * ChatInputChangeEvent}.
+   * <p>
+   * If the chat is currently not opened, only this event will be fired.
    *
    * @param text      The new non-null text to be set in the chat input
    * @param overwrite {@code true} if the current input value should be replaced, {@code false} if

--- a/mcapi/src/main/java/net/flintmc/mcapi/chat/ChatController.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/chat/ChatController.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import net.flintmc.mcapi.chat.component.ChatComponent;
+import net.flintmc.mcapi.chat.event.ChatInputChangeEvent;
 import net.flintmc.mcapi.chat.suggestion.SuggestionList;
 
 /**
@@ -42,6 +43,16 @@ public interface ChatController {
    * @return Whether the message was sent successfully or cancelled by an event handler
    */
   boolean dispatchChatInput(String message);
+
+  /**
+   * Sets the current value of the text field in the chat and fires the {@link
+   * ChatInputChangeEvent}, if the chat is currently not opened, only this event will be fired.
+   *
+   * @param text      The new non-null text to be set in the chat input
+   * @param overwrite {@code true} if the current input value should be replaced, {@code false} if
+   *                  the new value should be appended to the current value
+   */
+  void setInputValue(String text, boolean overwrite);
 
   /**
    * The history of the chat input by the player. This will be filled when the player types

--- a/mcapi/src/main/java/net/flintmc/mcapi/chat/component/event/ClickActionExecutor.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/chat/component/event/ClickActionExecutor.java
@@ -1,0 +1,37 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.chat.component.event;
+
+/**
+ * Executor for a {@link ClickEvent}.
+ * <p>
+ * This interface should be used together with the {@link ClickEventAction} annotation to
+ * automatically register it.
+ */
+public interface ClickActionExecutor {
+
+  /**
+   * Executes the given click event as if the user would have clicked on the component in the chat.
+   *
+   * @param event The non-null event to be executed
+   */
+  void executeEvent(ClickEvent event);
+
+}

--- a/mcapi/src/main/java/net/flintmc/mcapi/chat/component/event/ClickActionExecutor.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/chat/component/event/ClickActionExecutor.java
@@ -22,8 +22,8 @@ package net.flintmc.mcapi.chat.component.event;
 /**
  * Executor for a {@link ClickEvent}.
  * <p>
- * This interface should be used together with the {@link ClickEventAction} annotation to
- * automatically register it.
+ * An implementation of this interface should be used together with the {@link ClickEventAction}
+ * annotation to automatically register it.
  */
 public interface ClickActionExecutor {
 
@@ -33,5 +33,4 @@ public interface ClickActionExecutor {
    * @param event The non-null event to be executed
    */
   void executeEvent(ClickEvent event);
-
 }

--- a/mcapi/src/main/java/net/flintmc/mcapi/chat/component/event/ClickEvent.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/chat/component/event/ClickEvent.java
@@ -26,121 +26,116 @@ package net.flintmc.mcapi.chat.component.event;
  * <p>ClickEvents for the chat are available since Minecraft 1.7.10. With Minecraft 1.8 and 1.15
  * some new actions have been added.
  */
-public class ClickEvent {
-
-  private final Action action;
-  private final String value;
-
-  private ClickEvent(Action action, String value) {
-    this.action = action;
-    this.value = value;
-  }
-
-  /**
-   * Creates a new click event with the given action and value.
-   *
-   * <p>Available since Minecraft 1.7.10.
-   *
-   * @param action The non-null action of the click event
-   * @param value  The non-null value of the click event
-   * @return The new non-null click event
-   * @see Action
-   */
-  public static ClickEvent of(Action action, String value) {
-    return new ClickEvent(action, value);
-  }
-
-  /**
-   * Creates a new click event which will open an URL in the Browser when the player clicks on it.
-   *
-   * <p>Available since Minecraft 1.7.10.
-   *
-   * @param url The url to be opened
-   * @return The new non-null click event
-   */
-  public static ClickEvent openUrl(String url) {
-    return of(Action.OPEN_URL, url);
-  }
-
-  /**
-   * Creates a new click event which will open a file on the local file system. For security
-   * reasons, this is only used internally to open screenshots in the chat and ignored when the
-   * server sends it.
-   *
-   * <p>Available since Minecraft 1.7.10.
-   *
-   * @param path The path to the file to be opened
-   * @return The new non-null click event
-   */
-  public static ClickEvent openFile(String path) {
-    return of(Action.OPEN_FILE, path);
-  }
-
-  /**
-   * Creates a new click event which will send the given command as a normal chat message to the
-   * server.
-   *
-   * <p>Available since Minecraft 1.7.10.
-   *
-   * @param command The command to be sent to the server
-   * @return The new non-null click event
-   */
-  public static ClickEvent runCommand(String command) {
-    return of(Action.RUN_COMMAND, command);
-  }
-
-  /**
-   * Creates a new click event which will fill the chat input with given command.
-   *
-   * <p>Available since Minecraft 1.7.10.
-   *
-   * @param command The command for the chat
-   * @return The new non-null click event
-   */
-  public static ClickEvent suggestCommand(String command) {
-    return of(Action.SUGGEST_COMMAND, command);
-  }
-
-  /**
-   * Creates a new click event which will copy the given content to the clipboard of the user.
-   *
-   * <p>Available since Minecraft 1.15.
-   *
-   * @param content The content for the clipboard
-   * @return The new non-null click event
-   */
-  public static ClickEvent copyToClipboard(String content) {
-    return of(Action.COPY_TO_CLIPBOARD, content);
-  }
-
-  /**
-   * Creates a new click event which will change the page in the currently opened book, this event
-   * has no effect when used somewhere else than a book.
-   *
-   * <p>Available since Minecraft 1.8.
-   *
-   * @param page The number of the page to be opened
-   * @return The new non-null click event
-   */
-  public static ClickEvent changeBookPage(int page) {
-    return of(Action.CHANGE_PAGE, String.valueOf(page));
-  }
+public interface ClickEvent {
 
   /**
    * Retrieves the non-null action of this click event.
+   *
+   * @return The non-null action of this click event
    */
-  public Action getAction() {
-    return this.action;
-  }
+  Action getAction();
 
   /**
    * Retrieves the non-null value of this click event.
+   *
+   * @return The non-null value of this click event
    */
-  public String getValue() {
-    return this.value;
+  String getValue();
+
+  /**
+   * Runs this click event, for example if the {@link #getAction() action} is {@link
+   * Action#COPY_TO_CLIPBOARD}, the {@link #getValue() value} will be copied into the clipboard.
+   */
+  void execute();
+
+  /**
+   * Factory for the {@link ClickEvent}.
+   */
+  interface Factory {
+
+    /**
+     * Creates a new click event with the given action and value.
+     *
+     * <p>Available since Minecraft 1.7.10.
+     *
+     * @param action The non-null action of the click event
+     * @param value  The non-null value of the click event
+     * @return The new non-null click event
+     * @see Action
+     */
+    ClickEvent create(Action action, String value);
+
+    /**
+     * Creates a new click event which will open an URL in the Browser when the player clicks on
+     * it.
+     *
+     * <p>Available since Minecraft 1.7.10.
+     *
+     * @param url The url to be opened
+     * @return The new non-null click event
+     */
+    ClickEvent openUrl(String url);
+
+    /**
+     * Creates a new click event which will open a file on the local file system. For security
+     * reasons, this is only used internally to open screenshots in the chat and ignored when the
+     * server sends it.
+     *
+     * <p>Available since Minecraft 1.7.10.
+     *
+     * @param path The path to the file to be opened
+     * @return The new non-null click event
+     */
+    ClickEvent openFile(String path);
+
+    /**
+     * Creates a new click event which will send the given command as a normal chat message to the
+     * server.
+     *
+     * <p>Available since Minecraft 1.7.10.
+     *
+     * @param command The command to be sent to the server
+     * @return The new non-null click event
+     */
+    ClickEvent runCommand(String command);
+
+    /**
+     * Creates a new click event which will fill the chat input with given command.
+     *
+     * <p>Available since Minecraft 1.7.10.
+     *
+     * @param command The command for the chat
+     * @return The new non-null click event
+     */
+    ClickEvent suggestCommand(String command);
+
+    /**
+     * Creates a new click event which will copy the given content to the clipboard of the user.
+     *
+     * <p>Available since Minecraft 1.15.
+     *
+     * @param content The content for the clipboard
+     * @return The new non-null click event
+     */
+    ClickEvent copyToClipboard(String content);
+
+    /**
+     * Creates a new click event which will change the page in the currently opened book, this event
+     * has no effect when used somewhere else than a book.
+     *
+     * <p>Available since Minecraft 1.8.
+     *
+     * @param page The number of the page to be opened
+     * @return The new non-null click event
+     */
+    ClickEvent changeBookPage(int page);
+
   }
 
-  public enum Action {
+  /**
+   * An enumeration representing all possible actions for a {@link ClickEvent}.
+   */
+  enum Action {
 
     /**
      * Opens an URL in the Browser of the player.
@@ -151,7 +146,7 @@ public class ClickEvent {
 
     /**
      * Opens a file on the local file system of the player. For security reasons, this is only used
-     * internally to open screenshots in the chat.
+     * internally and will be ignored if sent by servers.
      *
      * <p>Available since Minecraft 1.7.10.
      */
@@ -192,6 +187,11 @@ public class ClickEvent {
       this.lowerName = super.name().toLowerCase();
     }
 
+    /**
+     * Retrieves the {@link #name()} of this enum constant in the lower case.
+     *
+     * @return The non-null lower case name of this enum constant
+     */
     public String getLowerName() {
       return this.lowerName;
     }

--- a/mcapi/src/main/java/net/flintmc/mcapi/chat/component/event/ClickEventAction.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/chat/component/event/ClickEventAction.java
@@ -1,0 +1,52 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.chat.component.event;
+
+import net.flintmc.mcapi.chat.component.event.ClickEvent.Action;
+import net.flintmc.metaprogramming.DetectableAnnotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a {@link ClickActionExecutor} to be automatically registered and used by {@link
+ * ClickEvent#execute()}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@DetectableAnnotation
+public @interface ClickEventAction {
+
+  /**
+   * Retrieves the action for which the annotated class should be executed.
+   *
+   * @return The non-null action of the annotated executor
+   */
+  Action value();
+
+  /**
+   * Retrieves the priority of this action executor. Higher priorities will be preferred, but every
+   * executor for the specific action will be executed.
+   *
+   * @return The priority, this can be any integer
+   */
+  int priority() default 1;
+}

--- a/mcapi/src/main/java/net/flintmc/mcapi/chat/event/ChatInputChangeEvent.java
+++ b/mcapi/src/main/java/net/flintmc/mcapi/chat/event/ChatInputChangeEvent.java
@@ -1,0 +1,66 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.chat.event;
+
+import net.flintmc.framework.eventbus.event.Event;
+import net.flintmc.framework.eventbus.event.subscribe.Subscribable;
+import net.flintmc.framework.eventbus.event.subscribe.Subscribe;
+import net.flintmc.framework.eventbus.event.subscribe.Subscribe.Phase;
+import net.flintmc.framework.generation.annotation.DataFactory;
+import net.flintmc.framework.generation.annotation.TargetDataField;
+import net.flintmc.mcapi.chat.ChatController;
+
+/**
+ * This event will be fired whenever the content of the chat input line has been changed through a
+ * click event or any other way to manually set the input like {@link
+ * ChatController#setInputValue(String, boolean)}, it will never be fired just because the user
+ * types something into the chat.
+ * <p>
+ * It will only be fired in the {@link Phase#POST} phase.
+ *
+ * @see Subscribe
+ */
+@Subscribable(Phase.POST)
+public interface ChatInputChangeEvent extends Event {
+
+  /**
+   * Retrieves the text to which the chat input has been changed.
+   *
+   * @return The non-null text to which the chat input has been changed
+   */
+  @TargetDataField("newValue")
+  String getNewValue();
+
+  /**
+   * Factory for the {@link ChatInputChangeEvent}.
+   */
+  @DataFactory(ChatInputChangeEvent.class)
+  interface Factory {
+
+    /**
+     * Creates a new {@link ChatInputChangeEvent} for the given new value.
+     *
+     * @param newValue The non-null text to which the chat input has been changed
+     * @return The new non-null event
+     */
+    ChatInputChangeEvent create(@TargetDataField("newValue") String newValue);
+  }
+
+}

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/chat/ScreenTextShadow.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/chat/ScreenTextShadow.java
@@ -1,0 +1,31 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_15_2.chat;
+
+import net.flintmc.transform.shadow.MethodProxy;
+import net.flintmc.transform.shadow.Shadow;
+
+@Shadow("net.minecraft.client.gui.screen.Screen")
+public interface ScreenTextShadow {
+
+  @MethodProxy("insertText")
+  void setChatInput(String text, boolean overwrite);
+
+}

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/chat/VersionedChatController.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/chat/VersionedChatController.java
@@ -31,13 +31,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import net.flintmc.framework.eventbus.EventBus;
+import net.flintmc.framework.eventbus.event.subscribe.Subscribe.Phase;
 import net.flintmc.framework.inject.implement.Implement;
 import net.flintmc.framework.stereotype.type.Type;
 import net.flintmc.mcapi.chat.ChatController;
 import net.flintmc.mcapi.chat.ChatLocation;
 import net.flintmc.mcapi.chat.MinecraftComponentMapper;
-import net.flintmc.mcapi.chat.suggestion.Suggestion;
 import net.flintmc.mcapi.chat.component.ChatComponent;
+import net.flintmc.mcapi.chat.event.ChatInputChangeEvent;
+import net.flintmc.mcapi.chat.suggestion.Suggestion;
 import net.flintmc.mcapi.chat.suggestion.SuggestionList;
 import net.flintmc.mcapi.chat.suggestion.SuggestionList.Factory;
 import net.flintmc.mcapi.player.network.NetworkPlayerInfo;
@@ -47,6 +50,8 @@ import net.flintmc.transform.hook.Hook.ExecutionTime;
 import net.flintmc.transform.hook.HookResult;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ChatLine;
+import net.minecraft.client.gui.screen.ChatScreen;
+import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.network.play.ClientPlayNetHandler;
 import net.minecraft.network.play.client.CTabCompletePacket;
 import net.minecraft.util.text.ChatType;
@@ -62,6 +67,9 @@ public class VersionedChatController implements ChatController {
   private final MinecraftComponentMapper componentMapper;
   private final NetworkPlayerInfoRegistry playerInfoRegistry;
 
+  private final EventBus eventBus;
+  private final ChatInputChangeEvent.Factory inputChangeEventFactory;
+
   private final SuggestionList.Factory suggestionListFactory;
   private final SuggestionList emptySuggestionList;
   private final Suggestion.Factory suggestionFactory;
@@ -72,10 +80,16 @@ public class VersionedChatController implements ChatController {
   private VersionedChatController(
       MinecraftComponentMapper componentMapper,
       NetworkPlayerInfoRegistry playerInfoRegistry,
+      EventBus eventBus,
+      ChatInputChangeEvent.Factory inputChangeEventFactory,
       Factory suggestionListFactory,
       Suggestion.Factory suggestionFactory) {
     this.componentMapper = componentMapper;
     this.playerInfoRegistry = playerInfoRegistry;
+
+    this.eventBus = eventBus;
+    this.inputChangeEventFactory = inputChangeEventFactory;
+
     this.suggestionListFactory = suggestionListFactory;
     this.emptySuggestionList = suggestionListFactory.create(0, 0, Collections.emptyList());
     this.suggestionFactory = suggestionFactory;
@@ -97,6 +111,21 @@ public class VersionedChatController implements ChatController {
     Minecraft.getInstance().player.sendChatMessage(message);
     Minecraft.getInstance().ingameGUI.getChatGUI().addToSentMessages(message);
     return true;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void setInputValue(String text, boolean overwrite) {
+    Screen screen = Minecraft.getInstance().currentScreen;
+    if (screen instanceof ChatScreen) {
+      ((ScreenTextShadow) screen).setChatInput(text, true);
+    } else {
+      // We can ignore the overwrite value because if the chat is not opened
+      // there will be nothing to append the text to
+      this.eventBus.fireEvent(this.inputChangeEventFactory.create(text), Phase.POST);
+    }
   }
 
   /**

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/chat/VersionedMinecraftComponentMapper.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/chat/VersionedMinecraftComponentMapper.java
@@ -34,6 +34,7 @@ import net.flintmc.mcapi.chat.component.SelectorComponent;
 import net.flintmc.mcapi.chat.component.TextComponent;
 import net.flintmc.mcapi.chat.component.TranslationComponent;
 import net.flintmc.mcapi.chat.component.event.ClickEvent;
+import net.flintmc.mcapi.chat.component.event.ClickEvent.Action;
 import net.flintmc.mcapi.chat.component.event.HoverEvent;
 import net.flintmc.mcapi.chat.component.event.content.HoverContent;
 import net.flintmc.mcapi.chat.exception.ComponentDeserializationException;
@@ -55,12 +56,16 @@ public class VersionedMinecraftComponentMapper implements MinecraftComponentMapp
 
   private final ComponentBuilder.Factory builderFactory;
   private final ComponentSerializer.Factory factory;
+  private final ClickEvent.Factory clickEventFactory;
 
   @Inject
   private VersionedMinecraftComponentMapper(
-      Factory builderFactory, ComponentSerializer.Factory factory) {
+      Factory builderFactory,
+      ComponentSerializer.Factory factory,
+      ClickEvent.Factory clickEventFactory) {
     this.builderFactory = builderFactory;
     this.factory = factory;
+    this.clickEventFactory = clickEventFactory;
   }
 
   @Override
@@ -185,15 +190,13 @@ public class VersionedMinecraftComponentMapper implements MinecraftComponentMapp
     }
 
     if (style.getClickEvent() != null) {
-      component.clickEvent(
-          ClickEvent.of(
-              ClickEvent.Action.valueOf(style.getClickEvent().getAction().name()),
-              style.getClickEvent().getValue()));
+      component.clickEvent(this.clickEventFactory.create(
+          this.mapClickEventAction(style.getClickEvent().getAction()),
+          style.getClickEvent().getValue()));
     }
 
     if (style.getHoverEvent() != null) {
-      HoverEvent.Action action =
-          HoverEvent.Action.valueOf(style.getHoverEvent().getAction().name());
+      HoverEvent.Action action = this.mapHoverEventAction(style.getHoverEvent().getAction());
       ITextComponent value = style.getHoverEvent().getValue();
 
       HoverContent content =
@@ -205,6 +208,38 @@ public class VersionedMinecraftComponentMapper implements MinecraftComponentMapp
     }
 
     component.insertion(style.getInsertion());
+  }
+
+  private ClickEvent.Action mapClickEventAction(
+      net.minecraft.util.text.event.ClickEvent.Action action) {
+    switch (action) {
+      case OPEN_URL:
+        return Action.OPEN_URL;
+      case OPEN_FILE:
+        return Action.OPEN_FILE;
+      case RUN_COMMAND:
+        return Action.RUN_COMMAND;
+      case CHANGE_PAGE:
+        return Action.CHANGE_PAGE;
+      case COPY_TO_CLIPBOARD:
+        return Action.COPY_TO_CLIPBOARD;
+      default:
+      case SUGGEST_COMMAND:
+        return Action.SUGGEST_COMMAND;
+    }
+  }
+
+  private HoverEvent.Action mapHoverEventAction(
+      net.minecraft.util.text.event.HoverEvent.Action action) {
+    switch (action) {
+      default:
+      case SHOW_TEXT:
+        return HoverEvent.Action.SHOW_TEXT;
+      case SHOW_ITEM:
+        return HoverEvent.Action.SHOW_ITEM;
+      case SHOW_ENTITY:
+        return HoverEvent.Action.SHOW_ENTITY;
+    }
   }
 
   private ITextComponent createMinecraftComponent(ChatComponent component) {

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/chat/component/event/VersionedClipboardActionExecutor.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/chat/component/event/VersionedClipboardActionExecutor.java
@@ -1,0 +1,40 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_15_2.chat.component.event;
+
+import com.google.inject.Singleton;
+import net.flintmc.mcapi.chat.component.event.ClickActionExecutor;
+import net.flintmc.mcapi.chat.component.event.ClickEvent;
+import net.flintmc.mcapi.chat.component.event.ClickEvent.Action;
+import net.flintmc.mcapi.chat.component.event.ClickEventAction;
+import net.minecraft.client.Minecraft;
+
+@Singleton
+@ClickEventAction(value = Action.COPY_TO_CLIPBOARD, priority = 0)
+public class VersionedClipboardActionExecutor implements ClickActionExecutor {
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void executeEvent(ClickEvent event) {
+    Minecraft.getInstance().keyboardListener.setClipboardString(event.getValue());
+  }
+}

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/chat/component/event/VersionedOpenFileActionExecutor.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/chat/component/event/VersionedOpenFileActionExecutor.java
@@ -1,0 +1,41 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_15_2.chat.component.event;
+
+import com.google.inject.Singleton;
+import java.io.File;
+import net.flintmc.mcapi.chat.component.event.ClickActionExecutor;
+import net.flintmc.mcapi.chat.component.event.ClickEvent;
+import net.flintmc.mcapi.chat.component.event.ClickEvent.Action;
+import net.flintmc.mcapi.chat.component.event.ClickEventAction;
+import net.minecraft.util.Util;
+
+@Singleton
+@ClickEventAction(value = Action.OPEN_FILE, priority = 0)
+public class VersionedOpenFileActionExecutor implements ClickActionExecutor {
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void executeEvent(ClickEvent event) {
+    Util.getOSType().openFile(new File(event.getValue()));
+  }
+}

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/chat/component/event/VersionedOpenUrlActionExecutor.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/chat/component/event/VersionedOpenUrlActionExecutor.java
@@ -1,0 +1,88 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_15_2.chat.component.event;
+
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Set;
+import net.flintmc.framework.inject.logging.InjectLogger;
+import net.flintmc.mcapi.chat.component.event.ClickActionExecutor;
+import net.flintmc.mcapi.chat.component.event.ClickEvent;
+import net.flintmc.mcapi.chat.component.event.ClickEvent.Action;
+import net.flintmc.mcapi.chat.component.event.ClickEventAction;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screen.ConfirmOpenLinkScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.util.Util;
+import org.apache.logging.log4j.Logger;
+
+@Singleton
+@ClickEventAction(value = Action.OPEN_URL, priority = 0)
+public class VersionedOpenUrlActionExecutor implements ClickActionExecutor {
+
+  private static final Set<String> ALLOWED_PROTOCOLS = Sets.newHashSet("http", "https");
+
+  private final Logger logger;
+
+  @Inject
+  private VersionedOpenUrlActionExecutor(@InjectLogger Logger logger) {
+    this.logger = logger;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void executeEvent(ClickEvent event) {
+    try {
+      String value = event.getValue();
+
+      URI uri = new URI(value);
+      String scheme = uri.getScheme();
+      if (scheme == null) {
+        throw new URISyntaxException(value, "Missing protocol");
+      }
+
+      if (!ALLOWED_PROTOCOLS.contains(scheme.toLowerCase())) {
+        throw new URISyntaxException(value, "Unsupported URI scheme: " + scheme);
+      }
+
+      if (Minecraft.getInstance().gameSettings.chatLinksPrompt) {
+        Screen previousScreen = Minecraft.getInstance().currentScreen;
+
+        Minecraft.getInstance().displayGuiScreen(new ConfirmOpenLinkScreen(accepted -> {
+          if (accepted) {
+            Util.getOSType().openURI(uri);
+          }
+
+          Minecraft.getInstance().displayGuiScreen(previousScreen);
+        }, value, false));
+        return;
+      }
+
+      Util.getOSType().openURI(uri);
+    } catch (URISyntaxException e) {
+      this.logger.error("Invalid URI: {}", event.getValue(), e);
+    }
+  }
+}

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/chat/component/event/VersionedRunCommandActionExecutor.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/chat/component/event/VersionedRunCommandActionExecutor.java
@@ -1,0 +1,48 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_15_2.chat.component.event;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import net.flintmc.mcapi.chat.ChatController;
+import net.flintmc.mcapi.chat.component.event.ClickActionExecutor;
+import net.flintmc.mcapi.chat.component.event.ClickEvent;
+import net.flintmc.mcapi.chat.component.event.ClickEvent.Action;
+import net.flintmc.mcapi.chat.component.event.ClickEventAction;
+
+@Singleton
+@ClickEventAction(value = Action.RUN_COMMAND, priority = 0)
+public class VersionedRunCommandActionExecutor implements ClickActionExecutor {
+
+  private final ChatController chatController;
+
+  @Inject
+  private VersionedRunCommandActionExecutor(ChatController chatController) {
+    this.chatController = chatController;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void executeEvent(ClickEvent event) {
+    this.chatController.dispatchChatInput(event.getValue());
+  }
+}

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/chat/component/event/VersionedSuggestCommandActionExecutor.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/chat/component/event/VersionedSuggestCommandActionExecutor.java
@@ -1,0 +1,48 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_15_2.chat.component.event;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import net.flintmc.mcapi.chat.ChatController;
+import net.flintmc.mcapi.chat.component.event.ClickActionExecutor;
+import net.flintmc.mcapi.chat.component.event.ClickEvent;
+import net.flintmc.mcapi.chat.component.event.ClickEvent.Action;
+import net.flintmc.mcapi.chat.component.event.ClickEventAction;
+
+@Singleton
+@ClickEventAction(value = Action.SUGGEST_COMMAND, priority = 0)
+public class VersionedSuggestCommandActionExecutor implements ClickActionExecutor {
+
+  private final ChatController chatController;
+
+  @Inject
+  private VersionedSuggestCommandActionExecutor(ChatController chatController) {
+    this.chatController = chatController;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void executeEvent(ClickEvent event) {
+    this.chatController.setInputValue(event.getValue(), true);
+  }
+}

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/chat/event/ChatEventInjector.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/chat/event/ChatEventInjector.java
@@ -17,15 +17,11 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package net.flintmc.mcapi.v1_16_5.chat;
+package net.flintmc.mcapi.v1_15_2.chat.event;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import javassist.CannotCompileException;
-import javassist.CtClass;
-import javassist.CtField;
-import javassist.CtMethod;
-import javassist.NotFoundException;
+import javassist.*;
 import net.flintmc.framework.eventbus.EventBus;
 import net.flintmc.framework.eventbus.event.subscribe.Subscribe;
 import net.flintmc.framework.inject.InjectedFieldBuilder;
@@ -73,7 +69,7 @@ public class ChatEventInjector {
     return classMapping.getMethodByIdentifier(name).getName();
   }
 
-  @ClassTransform("net.minecraft.client.gui.NewChatGui")
+  @ClassTransform(value = "net.minecraft.client.gui.NewChatGui")
   public void transformChatGui(ClassTransformContext context)
       throws NotFoundException, CannotCompileException {
     CtClass transforming = context.getCtClass();
@@ -108,11 +104,11 @@ public class ChatEventInjector {
       return null;
     }
 
-    return (ITextComponent) this.componentMapper.toMinecraft(event.getMessage());
+    return (ITextComponent) this.componentMapper
+        .toMinecraft(event.getMessage());
   }
 
-  @ClassTransform(
-      value = "net.minecraft.client.entity.player.ClientPlayerEntity")
+  @ClassTransform(value = "net.minecraft.client.entity.player.ClientPlayerEntity")
   public void transformClientPlayerEntity(ClassTransformContext context)
       throws CannotCompileException, NotFoundException {
     CtClass transforming = context.getCtClass();

--- a/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/chat/event/ChatInputChangeEventInjector.java
+++ b/mcapi/src/v1_15_2/java/net/flintmc/mcapi/v1_15_2/chat/event/ChatInputChangeEventInjector.java
@@ -1,0 +1,55 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_15_2.chat.event;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import net.flintmc.framework.eventbus.EventBus;
+import net.flintmc.framework.eventbus.event.subscribe.Subscribe.Phase;
+import net.flintmc.framework.stereotype.type.Type;
+import net.flintmc.mcapi.chat.event.ChatInputChangeEvent;
+import net.flintmc.transform.hook.Hook;
+import net.flintmc.transform.hook.Hook.ExecutionTime;
+
+@Singleton
+public class ChatInputChangeEventInjector {
+
+  private final EventBus eventBus;
+
+  private final ChatInputChangeEvent.Factory eventFactory;
+
+  @Inject
+  private ChatInputChangeEventInjector(
+      EventBus eventBus, ChatInputChangeEvent.Factory eventFactory) {
+    this.eventBus = eventBus;
+    this.eventFactory = eventFactory;
+  }
+
+  @Hook(
+      className = "net.minecraft.client.gui.screen.ChatScreen",
+      methodName = "func_212997_a",
+      parameters = @Type(reference = String.class),
+      executionTime = ExecutionTime.AFTER
+  )
+  public void onTextChanged(@Named("args") Object[] args) {
+    this.eventBus.fireEvent(this.eventFactory.create((String) args[0]), Phase.POST);
+  }
+}

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/chat/ScreenTextShadow.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/chat/ScreenTextShadow.java
@@ -1,0 +1,31 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_16_5.chat;
+
+import net.flintmc.transform.shadow.MethodProxy;
+import net.flintmc.transform.shadow.Shadow;
+
+@Shadow("net.minecraft.client.gui.screen.Screen")
+public interface ScreenTextShadow {
+
+  @MethodProxy("insertText")
+  void setChatInput(String text, boolean overwrite);
+
+}

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/chat/component/event/VersionedClipboardActionExecutor.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/chat/component/event/VersionedClipboardActionExecutor.java
@@ -1,0 +1,40 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_16_5.chat.component.event;
+
+import com.google.inject.Singleton;
+import net.flintmc.mcapi.chat.component.event.ClickActionExecutor;
+import net.flintmc.mcapi.chat.component.event.ClickEvent;
+import net.flintmc.mcapi.chat.component.event.ClickEvent.Action;
+import net.flintmc.mcapi.chat.component.event.ClickEventAction;
+import net.minecraft.client.Minecraft;
+
+@Singleton
+@ClickEventAction(value = Action.COPY_TO_CLIPBOARD, priority = -1)
+public class VersionedClipboardActionExecutor implements ClickActionExecutor {
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void executeEvent(ClickEvent event) {
+    Minecraft.getInstance().keyboardListener.setClipboardString(event.getValue());
+  }
+}

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/chat/component/event/VersionedClipboardActionExecutor.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/chat/component/event/VersionedClipboardActionExecutor.java
@@ -27,7 +27,7 @@ import net.flintmc.mcapi.chat.component.event.ClickEventAction;
 import net.minecraft.client.Minecraft;
 
 @Singleton
-@ClickEventAction(value = Action.COPY_TO_CLIPBOARD, priority = -1)
+@ClickEventAction(value = Action.COPY_TO_CLIPBOARD, priority = 0)
 public class VersionedClipboardActionExecutor implements ClickActionExecutor {
 
   /**

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/chat/component/event/VersionedOpenFileActionExecutor.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/chat/component/event/VersionedOpenFileActionExecutor.java
@@ -1,0 +1,41 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_16_5.chat.component.event;
+
+import com.google.inject.Singleton;
+import java.io.File;
+import net.flintmc.mcapi.chat.component.event.ClickActionExecutor;
+import net.flintmc.mcapi.chat.component.event.ClickEvent;
+import net.flintmc.mcapi.chat.component.event.ClickEvent.Action;
+import net.flintmc.mcapi.chat.component.event.ClickEventAction;
+import net.minecraft.util.Util;
+
+@Singleton
+@ClickEventAction(value = Action.OPEN_FILE, priority = 0)
+public class VersionedOpenFileActionExecutor implements ClickActionExecutor {
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void executeEvent(ClickEvent event) {
+    Util.getOSType().openFile(new File(event.getValue()));
+  }
+}

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/chat/component/event/VersionedOpenUrlActionExecutor.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/chat/component/event/VersionedOpenUrlActionExecutor.java
@@ -1,0 +1,88 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_16_5.chat.component.event;
+
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Set;
+import net.flintmc.framework.inject.logging.InjectLogger;
+import net.flintmc.mcapi.chat.component.event.ClickActionExecutor;
+import net.flintmc.mcapi.chat.component.event.ClickEvent;
+import net.flintmc.mcapi.chat.component.event.ClickEvent.Action;
+import net.flintmc.mcapi.chat.component.event.ClickEventAction;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screen.ConfirmOpenLinkScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.util.Util;
+import org.apache.logging.log4j.Logger;
+
+@Singleton
+@ClickEventAction(value = Action.OPEN_URL, priority = 0)
+public class VersionedOpenUrlActionExecutor implements ClickActionExecutor {
+
+  private static final Set<String> ALLOWED_PROTOCOLS = Sets.newHashSet("http", "https");
+
+  private final Logger logger;
+
+  @Inject
+  private VersionedOpenUrlActionExecutor(@InjectLogger Logger logger) {
+    this.logger = logger;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void executeEvent(ClickEvent event) {
+    try {
+      String value = event.getValue();
+
+      URI uri = new URI(value);
+      String scheme = uri.getScheme();
+      if (scheme == null) {
+        throw new URISyntaxException(value, "Missing protocol");
+      }
+
+      if (!ALLOWED_PROTOCOLS.contains(scheme.toLowerCase())) {
+        throw new URISyntaxException(value, "Unsupported URI scheme: " + scheme);
+      }
+
+      if (Minecraft.getInstance().gameSettings.chatLinksPrompt) {
+        Screen previousScreen = Minecraft.getInstance().currentScreen;
+
+        Minecraft.getInstance().displayGuiScreen(new ConfirmOpenLinkScreen(accepted -> {
+          if (accepted) {
+            Util.getOSType().openURI(uri);
+          }
+
+          Minecraft.getInstance().displayGuiScreen(previousScreen);
+        }, value, false));
+        return;
+      }
+
+      Util.getOSType().openURI(uri);
+    } catch (URISyntaxException e) {
+      this.logger.error("Invalid URI: {}", event.getValue(), e);
+    }
+  }
+}

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/chat/component/event/VersionedRunCommandActionExecutor.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/chat/component/event/VersionedRunCommandActionExecutor.java
@@ -1,0 +1,48 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_16_5.chat.component.event;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import net.flintmc.mcapi.chat.ChatController;
+import net.flintmc.mcapi.chat.component.event.ClickActionExecutor;
+import net.flintmc.mcapi.chat.component.event.ClickEvent;
+import net.flintmc.mcapi.chat.component.event.ClickEvent.Action;
+import net.flintmc.mcapi.chat.component.event.ClickEventAction;
+
+@Singleton
+@ClickEventAction(value = Action.RUN_COMMAND, priority = 0)
+public class VersionedRunCommandActionExecutor implements ClickActionExecutor {
+
+  private final ChatController chatController;
+
+  @Inject
+  private VersionedRunCommandActionExecutor(ChatController chatController) {
+    this.chatController = chatController;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void executeEvent(ClickEvent event) {
+    this.chatController.dispatchChatInput(event.getValue());
+  }
+}

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/chat/component/event/VersionedSuggestCommandActionExecutor.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/chat/component/event/VersionedSuggestCommandActionExecutor.java
@@ -1,0 +1,48 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_16_5.chat.component.event;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import net.flintmc.mcapi.chat.ChatController;
+import net.flintmc.mcapi.chat.component.event.ClickActionExecutor;
+import net.flintmc.mcapi.chat.component.event.ClickEvent;
+import net.flintmc.mcapi.chat.component.event.ClickEvent.Action;
+import net.flintmc.mcapi.chat.component.event.ClickEventAction;
+
+@Singleton
+@ClickEventAction(value = Action.SUGGEST_COMMAND, priority = 0)
+public class VersionedSuggestCommandActionExecutor implements ClickActionExecutor {
+
+  private final ChatController chatController;
+
+  @Inject
+  private VersionedSuggestCommandActionExecutor(ChatController chatController) {
+    this.chatController = chatController;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void executeEvent(ClickEvent event) {
+    this.chatController.setInputValue(event.getValue(), true);
+  }
+}

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/chat/event/ChatEventInjector.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/chat/event/ChatEventInjector.java
@@ -17,11 +17,15 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-package net.flintmc.mcapi.v1_15_2.chat;
+package net.flintmc.mcapi.v1_16_5.chat.event;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import javassist.*;
+import javassist.CannotCompileException;
+import javassist.CtClass;
+import javassist.CtField;
+import javassist.CtMethod;
+import javassist.NotFoundException;
 import net.flintmc.framework.eventbus.EventBus;
 import net.flintmc.framework.eventbus.event.subscribe.Subscribe;
 import net.flintmc.framework.inject.InjectedFieldBuilder;
@@ -69,7 +73,7 @@ public class ChatEventInjector {
     return classMapping.getMethodByIdentifier(name).getName();
   }
 
-  @ClassTransform(value = "net.minecraft.client.gui.NewChatGui")
+  @ClassTransform("net.minecraft.client.gui.NewChatGui")
   public void transformChatGui(ClassTransformContext context)
       throws NotFoundException, CannotCompileException {
     CtClass transforming = context.getCtClass();
@@ -104,11 +108,11 @@ public class ChatEventInjector {
       return null;
     }
 
-    return (ITextComponent) this.componentMapper
-        .toMinecraft(event.getMessage());
+    return (ITextComponent) this.componentMapper.toMinecraft(event.getMessage());
   }
 
-  @ClassTransform(value = "net.minecraft.client.entity.player.ClientPlayerEntity")
+  @ClassTransform(
+      value = "net.minecraft.client.entity.player.ClientPlayerEntity")
   public void transformClientPlayerEntity(ClassTransformContext context)
       throws CannotCompileException, NotFoundException {
     CtClass transforming = context.getCtClass();

--- a/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/chat/event/ChatInputChangeEventInjector.java
+++ b/mcapi/src/v1_16_5/java/net/flintmc/mcapi/v1_16_5/chat/event/ChatInputChangeEventInjector.java
@@ -1,0 +1,55 @@
+/*
+ * FlintMC
+ * Copyright (C) 2020-2021 LabyMedia GmbH and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package net.flintmc.mcapi.v1_16_5.chat.event;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import net.flintmc.framework.eventbus.EventBus;
+import net.flintmc.framework.eventbus.event.subscribe.Subscribe.Phase;
+import net.flintmc.framework.stereotype.type.Type;
+import net.flintmc.mcapi.chat.event.ChatInputChangeEvent;
+import net.flintmc.transform.hook.Hook;
+import net.flintmc.transform.hook.Hook.ExecutionTime;
+
+@Singleton
+public class ChatInputChangeEventInjector {
+
+  private final EventBus eventBus;
+
+  private final ChatInputChangeEvent.Factory eventFactory;
+
+  @Inject
+  private ChatInputChangeEventInjector(
+      EventBus eventBus, ChatInputChangeEvent.Factory eventFactory) {
+    this.eventBus = eventBus;
+    this.eventFactory = eventFactory;
+  }
+
+  @Hook(
+      className = "net.minecraft.client.gui.screen.ChatScreen",
+      methodName = "func_212997_a",
+      parameters = @Type(reference = String.class),
+      executionTime = ExecutionTime.AFTER
+  )
+  public void onTextChanged(@Named("args") Object[] args) {
+    this.eventBus.fireEvent(this.eventFactory.create((String) args[0]), Phase.POST);
+  }
+}


### PR DESCRIPTION
Adds a method to the ClickEvent for chat components to execute it just like a user would click on it in the chat.

Additionally, there is the ChatInputChangeEvent that will be fired when the chat input is changed through a click event or something else other than the direct user input.