### PR TITLE
Full Java 16 support

### DIFF
--- a/framework/inject-primitive/build.gradle.kts
+++ b/framework/inject-primitive/build.gradle.kts
@@ -24,7 +24,5 @@ plugins {
 group = "net.flintmc"
 
 dependencies {
-
-    api("com.google.inject", "guice", "4.2.0")
-
+    api("ca.stellardrift.guice-backport", "guice", "5.0.1")
 }

--- a/framework/stereotype/build.gradle.kts
+++ b/framework/stereotype/build.gradle.kts
@@ -35,9 +35,8 @@ dependencies {
     api("net.flintmc.installer", "launcher-plugin", "1.1.12")
 
     api("com.google.guava", "guava", "21.0")
-    api("com.google.inject", "guice", "4.2.0")
+    api("ca.stellardrift.guice-backport", "guice", "5.0.1")
     api("org.apache.commons", "commons-lang3", "3.9")
     api("org.codehaus.groovy", "groovy-all", "3.0.2")
     api("org.javassist", "javassist", "3.27.0-GA")
-
 }

--- a/transform/minecraft-obfuscator/src/main/java/net/flintmc/transform/minecraft/obfuscate/remap/MinecraftClassRemapper.java
+++ b/transform/minecraft-obfuscator/src/main/java/net/flintmc/transform/minecraft/obfuscate/remap/MinecraftClassRemapper.java
@@ -21,6 +21,10 @@ package net.flintmc.transform.minecraft.obfuscate.remap;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import javassist.ClassPool;
 import javassist.CtClass;
 import javassist.NotFoundException;
@@ -37,10 +41,6 @@ import org.objectweb.asm.Handle;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.SimpleRemapper;
 import org.objectweb.asm.tree.ClassNode;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Loads and provides mappings for a {@link org.objectweb.asm.commons.ClassRemapper},
@@ -54,16 +54,18 @@ public class MinecraftClassRemapper extends SimpleRemapper {
   private Handle lastHandle;
 
   @Inject
-  private MinecraftClassRemapper(ClassPool pool,
+  private MinecraftClassRemapper(
+      ClassPool pool,
       ClassMappingProvider classMappingProvider) {
     super(collectMappings(pool, classMappingProvider));
     this.classMappingProvider = classMappingProvider;
-    assert this.getClass().getClassLoader() instanceof RootClassLoader;
-    this.rootClassLoader = (RootClassLoader) getClass().getClassLoader();
+    assert super.getClass().getClassLoader() instanceof RootClassLoader;
+    this.rootClassLoader = (RootClassLoader) super.getClass().getClassLoader();
     this.rootClassLoader.excludeFromModification("org.objectweb.asm.");
   }
 
-  private static Map<String, String> collectMappings(ClassPool pool,
+  private static Map<String, String> collectMappings(
+      ClassPool pool,
       ClassMappingProvider classMappingProvider) {
     Map<String, String> mappings = new HashMap<>();
 

--- a/util/commons/build.gradle.kts
+++ b/util/commons/build.gradle.kts
@@ -25,7 +25,7 @@ group = "net.flintmc"
 
 dependencies {
     api("org.joml", "joml", "1.9.25")
-    api("com.google.inject", "guice", "4.2.0")
+    api("ca.stellardrift.guice-backport", "guice", "5.0.1")
 
     implementation("com.google.auto.service", "auto-service", "1.0-rc6")
 }

--- a/util/mapping/src/main/java/net/flintmc/util/mappings/MethodMapping.java
+++ b/util/mapping/src/main/java/net/flintmc/util/mappings/MethodMapping.java
@@ -19,7 +19,6 @@
 
 package net.flintmc.util.mappings;
 
-import com.google.inject.internal.cglib.core.$RejectModifierPredicate;
 import javassist.ClassPool;
 import javassist.CtClass;
 import javassist.CtMethod;

--- a/util/unit-testing/build.gradle.kts
+++ b/util/unit-testing/build.gradle.kts
@@ -27,6 +27,6 @@ dependencies {
     api(platform("org.junit:junit-bom:5.7.0"))
     api("org.junit.jupiter", "junit-jupiter", "5.7.0")
     api("org.junit.jupiter", "junit-jupiter-api", "5.7.0")
-    api("com.google.inject", "guice", "4.2.0")
+    api("ca.stellardrift.guice-backport", "guice", "5.0.1")
     api("org.mockito:mockito-core:3.7.7")
 }


### PR DESCRIPTION
Use Guice 5.0.1 backport to allow full Java 16 support.
The backport is needed to be able to use DependencyAndSource. (https://github.com/google/guice/issues/1121)

This PR can only be merged when the installer is also updated to Guice 5.0.1