### PR TITLE
Remove class name in front of fields in the same class

### DIFF
--- a/framework/inject/src/internal/java/net/flintmc/framework/inject/internal/method/DefaultMethodInjectionUtils.java
+++ b/framework/inject/src/internal/java/net/flintmc/framework/inject/internal/method/DefaultMethodInjectionUtils.java
@@ -98,10 +98,13 @@ public class DefaultMethodInjectionUtils implements MethodInjectionUtils {
     target.addField(injectorField);
 
     String getterName = "getMethodInjector_" + injectorName;
+    String fieldAccessor =
+        (moved ? injectorField.getDeclaringClass().getName() + "." : "") + injectorName;
+
     String generate =
         String.format(
             "if (%s == null) { %1$s = %s.generate(%s.getDefault().getMethod(\"%s\", \"%s\"), %s.class); }",
-            injectorField.getDeclaringClass().getName() + "." + injectorName,
+            fieldAccessor,
             injectedFactory.getName(),
             ClassPool.class.getName(),
             targetClass,
@@ -111,7 +114,7 @@ public class DefaultMethodInjectionUtils implements MethodInjectionUtils {
         CtMethod.make(
             String.format(
                 "public static %s %s() { %s return %s; }",
-                ifc.getName(), getterName, generate, injectorName),
+                ifc.getName(), getterName, generate, fieldAccessor),
             target);
 
     try {

--- a/transform/hook/src/internal/java/net/flintmc/transform/hook/internal/HookService.java
+++ b/transform/hook/src/internal/java/net/flintmc/transform/hook/internal/HookService.java
@@ -143,12 +143,17 @@ public class HookService implements ServiceHandler<Hook> {
             .get()
             .generateInjector(target.getDeclaringClass(), hookMethod, HookInjector.class);
 
+    String getterDeclaringName = getter.getDeclaringClass().equals(target.getDeclaringClass())
+        ? ""
+        : getter.getDeclaringClass().getName();
+    String getterSrc =
+        (getterDeclaringName.isEmpty() ? "" : getterDeclaringName + ".") + getter.getName();
+
     // getMethodInjector().notifyHook(instance, args, executionTime)
     String notify =
         String.format(
-            "%s.%s().notifyHook(%s, $args, net.flintmc.transform.hook.Hook.ExecutionTime.%s);",
-            getter.getDeclaringClass().getName(),
-            getter.getName(),
+            "%s().notifyHook(%s, $args, net.flintmc.transform.hook.Hook.ExecutionTime.%s);",
+            getterSrc,
             Modifier.isStatic(target.getModifiers()) ? "null" : "$0",
             executionTime);
     String varName = "hookNotifyResult";


### PR DESCRIPTION
Somehow Javassist cannot compile source in some very specific cases when it failes to find a class.