### PR TITLE
Add support for meta and parent packages

### DIFF
--- a/framework/packages/build.gradle.kts
+++ b/framework/packages/build.gradle.kts
@@ -33,8 +33,8 @@ dependencies {
     api(project(":framework:framework-stereotype"))
     api(project(":util:util-commons"))
     api("com.google.code.gson", "gson", "2.8.6")
-    api("net.flintmc.installer", "logic", "1.1.12")
-    api("net.flintmc.installer", "logic-implementation", "1.1.12")
+    api("net.flintmc.installer", "logic", "2.0.1")
+    api("net.flintmc.installer", "logic-implementation", "2.0.1")
 
     internalImplementation(project(":framework:framework-inject", "internal"))
     internalImplementation(project(":framework:framework-service"))

--- a/framework/packages/src/internal/java/net/flintmc/framework/packages/internal/DefaultPackage.java
+++ b/framework/packages/src/internal/java/net/flintmc/framework/packages/internal/DefaultPackage.java
@@ -184,7 +184,7 @@ public class DefaultPackage implements Package {
   @Override
   public Package getParent() {
     String parentName = this.packageManifest.getParent();
-    return parentName == null ? null : this.resolver.resolvePackageByName(parentName);
+    return parentName == null ? null : this.resolver.resolvePackageByName(parentName, false);
   }
 
   @Override

--- a/framework/packages/src/internal/java/net/flintmc/framework/packages/internal/DefaultPackage.java
+++ b/framework/packages/src/internal/java/net/flintmc/framework/packages/internal/DefaultPackage.java
@@ -19,6 +19,12 @@
 
 package net.flintmc.framework.packages.internal;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.jar.JarFile;
 import javassist.ClassPool;
 import javassist.NotFoundException;
 import net.flintmc.framework.inject.InjectionService;
@@ -31,6 +37,7 @@ import net.flintmc.framework.packages.Package;
 import net.flintmc.framework.packages.PackageClassLoader;
 import net.flintmc.framework.packages.PackageManifest;
 import net.flintmc.framework.packages.PackageManifestLoader;
+import net.flintmc.framework.packages.PackageResolver;
 import net.flintmc.framework.packages.PackageState;
 import net.flintmc.framework.packages.localization.PackageLocalizationLoader;
 import net.flintmc.framework.service.ExtendedServiceLoader;
@@ -46,12 +53,6 @@ import net.flintmc.metaprogramming.identifier.ClassIdentifier;
 import net.flintmc.metaprogramming.identifier.MethodIdentifier;
 import net.flintmc.util.mappings.utils.RemappingMethodLocationResolver;
 import org.apache.logging.log4j.Logger;
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.jar.JarFile;
 
 /**
  * Default implementation of the {@link Package}.
@@ -63,6 +64,7 @@ public class DefaultPackage implements Package {
   private final PackageClassLoader.Factory classLoaderFactory;
   private final Logger logger;
   private final File jarFile;
+  private final PackageResolver resolver;
 
 
   private PackageLocalizationLoader localizationLoader;
@@ -82,6 +84,8 @@ public class DefaultPackage implements Package {
    * @param jar               The java IO jar file this package should be loaded from, must point to
    *                          the same file as the `file` parameter, or must be null if the package
    *                          has been loaded from the classpath
+   * @param resolver          The package resolver to be used to resolve references to other
+   *                          packages
    */
   @AssistedInject
   private DefaultPackage(
@@ -89,6 +93,7 @@ public class DefaultPackage implements Package {
       PackageLocalizationLoader localizationLoader,
       PackageManifestLoader manifestLoader,
       PackageClassLoader.Factory classLoaderFactory,
+      PackageResolver resolver,
       @InjectLogger Logger logger,
       @Assisted("jarFile") File jarFile,
       @Assisted("jar") JarFile jar) {
@@ -96,6 +101,7 @@ public class DefaultPackage implements Package {
     this.classLoaderFactory = classLoaderFactory;
     this.logger = logger;
     this.jarFile = jarFile;
+    this.resolver = resolver;
 
     if (jar != null) {
       // If the package should be loaded from a jar file, try to retrieve the
@@ -140,12 +146,14 @@ public class DefaultPackage implements Package {
   private DefaultPackage(
       ServiceRepository serviceRepository,
       PackageClassLoader.Factory classLoaderFactory,
+      PackageResolver resolver,
       @InjectLogger Logger logger,
       @Assisted("manifest") PackageManifest manifest) {
     this.serviceRepository = serviceRepository;
     this.classLoaderFactory = classLoaderFactory;
     this.logger = logger;
     this.jarFile = null;
+    this.resolver = resolver;
     this.localizationLoader = null;
     this.packageManifest = manifest;
     this.packageState = PackageState.NOT_LOADED;
@@ -166,6 +174,22 @@ public class DefaultPackage implements Package {
   public String getName() {
     return this.packageManifest != null ? this.packageManifest.getName()
         : jarFile.getName();
+  }
+
+  @Override
+  public String getGroup() {
+    return this.packageManifest != null ? this.packageManifest.getGroup() : jarFile.getName();
+  }
+
+  @Override
+  public Package getParent() {
+    String parentName = this.packageManifest.getParent();
+    return parentName == null ? null : this.resolver.resolvePackageByName(parentName);
+  }
+
+  @Override
+  public boolean isMetaPackage() {
+    return this.packageManifest.isMetaPackage();
   }
 
   /**

--- a/framework/packages/src/internal/java/net/flintmc/framework/packages/internal/DefaultPackageLoader.java
+++ b/framework/packages/src/internal/java/net/flintmc/framework/packages/internal/DefaultPackageLoader.java
@@ -248,6 +248,26 @@ public class DefaultPackageLoader implements PackageLoader {
   }
 
   /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Package findPackageByName(String name) {
+    return this.getAllPackages()
+        .stream()
+        .filter((p) -> p.getName().equals(name))
+        .findFirst()
+        .orElse(null);
+  }
+
+  @Override
+  public Package findLoadedPackageByName(String name) {
+    return this.getLoadedStream()
+        .filter((p) -> p.getName().equals(name))
+        .findFirst()
+        .orElse(null);
+  }
+
+  /**
    * Retrieves a log prefix for the given class. This will always be the name of the package if the
    * class has been loaded by a package class loader.
    *

--- a/framework/packages/src/internal/java/net/flintmc/framework/packages/internal/DefaultPackageManifestLoader.java
+++ b/framework/packages/src/internal/java/net/flintmc/framework/packages/internal/DefaultPackageManifestLoader.java
@@ -132,6 +132,14 @@ public class DefaultPackageManifestLoader implements PackageManifestLoader {
      * {@inheritDoc}
      */
     @Override
+    public String getGroup() {
+      return this.model.getGroup();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String getDisplayName() {
       return this.getName();
     }
@@ -142,6 +150,22 @@ public class DefaultPackageManifestLoader implements PackageManifestLoader {
     @Override
     public String getVersion() {
       return this.model.getVersion();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getParent() {
+      return this.model.getParent();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isMetaPackage() {
+      return this.model.isMetaPackage();
     }
 
     @Override

--- a/framework/packages/src/internal/java/net/flintmc/framework/packages/internal/DefaultPackageResolver.java
+++ b/framework/packages/src/internal/java/net/flintmc/framework/packages/internal/DefaultPackageResolver.java
@@ -40,9 +40,8 @@ public class DefaultPackageResolver implements PackageResolver {
   }
 
   @Override
-  public Package resolvePackageByName(String name) {
-    return loader.getAllPackages(true).stream().filter((p) -> p.getName().equals(name)).findFirst()
-        .orElse(null);
+  public Package resolvePackageByName(String name, boolean requireLoaded) {
+    return requireLoaded ? loader.findLoadedPackageByName(name) : loader.findPackageByName(name);
   }
 
   @Override

--- a/framework/packages/src/internal/java/net/flintmc/framework/packages/internal/DefaultPackageResolver.java
+++ b/framework/packages/src/internal/java/net/flintmc/framework/packages/internal/DefaultPackageResolver.java
@@ -22,10 +22,29 @@ package net.flintmc.framework.packages.internal;
 import net.flintmc.framework.inject.implement.Implement;
 import net.flintmc.framework.packages.Package;
 import net.flintmc.framework.packages.PackageClassLoader;
+import net.flintmc.framework.packages.PackageLoader;
 import net.flintmc.framework.packages.PackageResolver;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
 @Implement(PackageResolver.class)
+@Singleton
 public class DefaultPackageResolver implements PackageResolver {
+
+  private final PackageLoader loader;
+
+  @Inject
+  private DefaultPackageResolver(PackageLoader loader) {
+    this.loader = loader;
+  }
+
+  @Override
+  public Package resolvePackageByName(String name) {
+    return loader.getAllPackages(true).stream().filter((p) -> p.getName().equals(name)).findFirst()
+        .orElse(null);
+  }
+
   @Override
   public Package resolvePackage(Class<?> clazz) {
     ClassLoader classLoader = clazz.getClassLoader();

--- a/framework/packages/src/main/java/net/flintmc/framework/packages/Package.java
+++ b/framework/packages/src/main/java/net/flintmc/framework/packages/Package.java
@@ -48,6 +48,30 @@ public interface Package {
   String getName();
 
   /**
+   * Retrieves the group of this package. This method differs from {@link PackageManifest#getName()}
+   * as in that it falls back to the name of the file if no manifest is present.
+   *
+   * @return The group of this package
+   */
+  String getGroup();
+
+  /**
+   * Retrieves the parent package of this package. This method differs from
+   * {@link PackageManifest#getParent()} as in that it resolves the name of the parent package and
+   * returns a handle to it in case it is present.
+   *
+   * @return The parent package, or {@code null}, if none
+   */
+  Package getParent();
+
+  /**
+   * Determines whether this package is a meta package.
+   *
+   * @return {@code true} if this package is a meta package, {@code false} otherwise
+   */
+  boolean isMetaPackage();
+
+  /**
    * Retrieves the display name of this package. This method differs from {@link
    * PackageManifest#getDisplayName()} as in that it falls back to the name of the file if no
    * manifest is present.

--- a/framework/packages/src/main/java/net/flintmc/framework/packages/PackageLoader.java
+++ b/framework/packages/src/main/java/net/flintmc/framework/packages/PackageLoader.java
@@ -65,5 +65,21 @@ public interface PackageLoader {
    */
   Set<Package> getLoadedPackages(boolean withCorePackages);
 
+  /**
+   * Finds a package (regardless of its state) based on its name.
+   *
+   * @param name The non-null name of the package
+   * @return The found package, or {@code null}, if the package could not be found
+   */
+  Package findPackageByName(String name);
+
+  /**
+   * Finds a loaded packaged based on its name
+   *
+   * @param name The non-null name of the package
+   * @return The found package, or {@code null}, if the package could not be found
+   */
+  Package findLoadedPackageByName(String name);
+
   void load();
 }

--- a/framework/packages/src/main/java/net/flintmc/framework/packages/PackageLoader.java
+++ b/framework/packages/src/main/java/net/flintmc/framework/packages/PackageLoader.java
@@ -32,19 +32,38 @@ public interface PackageLoader {
 
   /**
    * Retrieves a set of all packages. This ignores the {@link PackageState} completely, which means
-   * this set may for example also contain errored or not loaded packages.
+   * this set may for example also contain errored or not loaded packages. The returned set does
+   * not include flint core packages.
    *
    * @return A set of all packages found by the loader
    */
   Set<Package> getAllPackages();
 
   /**
+   * Retrieves a set of all packages. This ignores the {@link PackageState} completely, which means
+   * this set may for example also contain errored or not loaded packages.
+   *
+   * @param withCorePackages If {@code true}, flint core packages will be returned as well
+   * @return A set of all packages found by the loader
+   */
+  Set<Package> getAllPackages(boolean withCorePackages);
+
+  /**
    * Retrieves a set of all packages which are in the {@link PackageState#LOADED} or {@link
-   * PackageState#ENABLED} state.
+   * PackageState#ENABLED} state. The returned set does not include flint core packages.
    *
    * @return A set of all loaded or enabled packages
    */
   Set<Package> getLoadedPackages();
+
+  /**
+   * Retrieves a set of all packages which are in the {@link PackageState#LOADED} or {@link
+   * PackageState#ENABLED} state.
+   *
+   * @param withCorePackages If {@code true}, flint core packages will be returned as well
+   * @return A set of all loaded or enabled packages
+   */
+  Set<Package> getLoadedPackages(boolean withCorePackages);
 
   void load();
 }

--- a/framework/packages/src/main/java/net/flintmc/framework/packages/PackageManifest.java
+++ b/framework/packages/src/main/java/net/flintmc/framework/packages/PackageManifest.java
@@ -34,6 +34,13 @@ public interface PackageManifest {
   String getName();
 
   /**
+   * Retrieves the group of the package.
+   *
+   * @return The group of the package
+   */
+  String getGroup();
+
+  /**
    * Retrieves the display name of the package. This will always be a human
    * readable string.
    *
@@ -47,6 +54,20 @@ public interface PackageManifest {
    * @return The version of the package
    */
   String getVersion();
+
+  /**
+   * Retrieves the parent package.
+   *
+   * @return The parent package, or {@code null}, if none
+   */
+  String getParent();
+
+  /**
+   * Determines whether the package containing this manifest is considered a meta package.
+   *
+   * @return Whether this package is a meta package
+   */
+  boolean isMetaPackage();
 
   /**
    * Retrieves tha version of the package.

--- a/framework/packages/src/main/java/net/flintmc/framework/packages/PackageResolver.java
+++ b/framework/packages/src/main/java/net/flintmc/framework/packages/PackageResolver.java
@@ -23,6 +23,14 @@ package net.flintmc.framework.packages;
 public interface PackageResolver {
 
   /**
+   * Resolves a package by its name.
+   *
+   * @param name The non-null name of the package to search for
+   * @return The package with the given name, or {@code null}, if no such package could be found
+   */
+  Package resolvePackageByName(String name);
+
+  /**
    * Resolves the package where the given class has been loaded.
    *
    * @param clazz The non-null class to resolve the package for

--- a/framework/packages/src/main/java/net/flintmc/framework/packages/PackageResolver.java
+++ b/framework/packages/src/main/java/net/flintmc/framework/packages/PackageResolver.java
@@ -26,9 +26,10 @@ public interface PackageResolver {
    * Resolves a package by its name.
    *
    * @param name The non-null name of the package to search for
+   * @param requireLoaded Whether the package has to be loaded
    * @return The package with the given name, or {@code null}, if no such package could be found
    */
-  Package resolvePackageByName(String name);
+  Package resolvePackageByName(String name, boolean requireLoaded);
 
   /**
    * Resolves the package where the given class has been loaded.

--- a/framework/stereotype/build.gradle.kts
+++ b/framework/stereotype/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     api(project(":util:util-commons"))
 
     api("net.flintmc.launcher", "flint-launcher", "1.0.1")
-    api("net.flintmc.installer", "launcher-plugin", "1.1.12")
+    api("net.flintmc.installer", "launcher-plugin", "2.0.1")
 
     api("com.google.guava", "guava", "21.0")
     api("com.google.inject", "guice", "4.2.0")


### PR DESCRIPTION
This PR adds support for meta and parent packages and adjust the package loader logic to be able to filter out flint core packages.