### PR TITLE
Remove javadoc publish

### DIFF
--- a/.github/workflows/gradle_publish.yml
+++ b/.github/workflows/gradle_publish.yml
@@ -57,29 +57,3 @@ jobs:
           FLINT_DISTRIBUTOR_PUBLISH_TOKEN: ${{ secrets.FLINT_DISTRIBUTOR_PUBLISH_TOKEN }}
           FLINT_DISTRIBUTOR_URL: ${{ secrets.FLINT_DISTRIBUTOR_URL }}
           FLINT_DISTRIBUTOR_AUTHORIZATION: ${{ secrets.FLINT_DISTRIBUTOR_AUTHORIZATION }}
-
-      - name: Publish Javadocs
-        working-directory: docs/generated
-        run: |
-          set -e
-          echo "Zipping javadocs..."
-          zip -r docs.zip *
-          echo "Uploading..."
-          upload_resp_and_code=$(curl -X POST -F "secret=${FLINT_JAVADOCS_PUBLISH_TOKEN}" -F "subdirectory=framework" -F "zip=@docs.zip" "${FLINT_JAVADOCS_URL}" -w "%{http_code}")
-
-          upload_resp=$(echo "${upload_resp_and_code}" | head -n -1)
-          status_code=$(echo "${upload_resp_and_code}" | tail -n 1 -c 4)
-
-          if [[ $status_code -eq 200 ]]; then
-            echo "Upload succeeded (${status_code}):"
-            echo "${upload_resp}"
-            exit 0
-          else
-            echo "Upload failed (${status_code}):"
-            echo "${upload_resp}"
-            exit 1
-          fi
-
-        env:
-          FLINT_JAVADOCS_URL: ${{ secrets.FLINT_JAVADOCS_URL }}
-          FLINT_JAVADOCS_PUBLISH_TOKEN: ${{ secrets.FLINT_JAVADOCS_PUBLISH_TOKEN }}


### PR DESCRIPTION
Remove javadoc publishing as the api endpoint is deprecated.